### PR TITLE
Add transactions support

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -221,9 +221,8 @@ class TestWithClause(TablesTest):
         )
         table.create(connection)
 
-        session: ydb.Session = connection.connection.driver_connection.pool.acquire()
+        session: ydb.Session = connection.connection.driver_connection.session
         table_description = session.describe_table("/local/" + table.name)
-        session.delete()
         return table_description
 
     @pytest.mark.parametrize(

--- a/test_dbapi/conftest.py
+++ b/test_dbapi/conftest.py
@@ -1,9 +1,10 @@
 import pytest
+
 import ydb_sqlalchemy.dbapi as dbapi
 
 
 @pytest.fixture(scope="module")
 def connection():
-    conn = dbapi.connect("localhost:2136", database="/local")
+    conn = dbapi.connect(host="localhost", port="2136", database="/local")
     yield conn
     conn.close()

--- a/ydb_sqlalchemy/__init__.py
+++ b/ydb_sqlalchemy/__init__.py
@@ -1,0 +1,1 @@
+from .dbapi import IsolationLevel  # noqa: F401

--- a/ydb_sqlalchemy/dbapi/__init__.py
+++ b/ydb_sqlalchemy/dbapi/__init__.py
@@ -1,4 +1,4 @@
-from .connection import Connection
+from .connection import Connection, IsolationLevel  # noqa: F401
 from .cursor import Cursor, YdbQuery  # noqa: F401
 from .errors import (
     Warning,

--- a/ydb_sqlalchemy/dbapi/connection.py
+++ b/ydb_sqlalchemy/dbapi/connection.py
@@ -1,24 +1,38 @@
 import posixpath
+from typing import Optional
 
 import ydb
 from .cursor import Cursor
-from .errors import InterfaceError, ProgrammingError, DatabaseError
+from .errors import InterfaceError, ProgrammingError, DatabaseError, InternalError, NotSupportedError
+
+
+class IsolationLevel:
+    SERIALIZABLE = "SERIALIZABLE"
+    ONLINE_READONLY = "ONLINE READONLY"
+    ONLINE_READONLY_INCONSISTENT = "ONLINE READONLY INCONSISTENT"
+    STALE_READONLY = "STALE READONLY"
+    SNAPSHOT_READONLY = "SNAPSHOT READONLY"
+    AUTOCOMMIT = "AUTOCOMMIT"
 
 
 class Connection:
     def __init__(self, endpoint=None, host=None, port=None, database=None, **conn_kwargs):
         self.endpoint = endpoint or f"grpc://{host}:{port}"
         self.database = database
-        self.driver = self._create_driver(self.endpoint, self.database, **conn_kwargs)
-        self.pool = ydb.SessionPool(self.driver)
+        self.table_client_settings = self._get_table_client_settings()
+        self.driver = self._create_driver(**conn_kwargs)
+        self.session = self._create_session()
+        self.interactive_transaction: bool = False  # AUTOCOMMIT
+        self.tx_mode: ydb.AbstractTransactionModeBuilder = ydb.SerializableReadWrite()
+        self.transaction: Optional[ydb.TxContext] = None
 
     def cursor(self):
-        return Cursor(self)
+        return Cursor(self, transaction=self.transaction)
 
     def describe(self, table_path):
         full_path = posixpath.join(self.database, table_path)
         try:
-            return self.pool.retry_operation_sync(lambda cli: cli.describe_table(full_path))
+            return ydb.retry_operation_sync(lambda: self.session.describe_table(full_path))
         except ydb.issues.SchemeError as e:
             raise ProgrammingError(e.message, e.issues, e.status) from e
         except ydb.Error as e:
@@ -33,30 +47,76 @@ class Connection:
         except ydb.SchemeError:
             return False
 
+    def set_isolation_level(self, isolation_level: str):
+        ydb_isolation_settings_map = {
+            IsolationLevel.AUTOCOMMIT: (ydb.SerializableReadWrite(), False),
+            IsolationLevel.SERIALIZABLE: (ydb.SerializableReadWrite(), True),
+            IsolationLevel.ONLINE_READONLY: (ydb.OnlineReadOnly(), False),
+            IsolationLevel.ONLINE_READONLY_INCONSISTENT: (ydb.OnlineReadOnly().with_allow_inconsistent_reads(), False),
+            IsolationLevel.STALE_READONLY: (ydb.StaleReadOnly(), False),
+            IsolationLevel.SNAPSHOT_READONLY: (ydb.SnapshotReadOnly(), True),
+        }
+        ydb_isolation_settings = ydb_isolation_settings_map[isolation_level]
+        if self.transaction and self.transaction.tx_id:
+            raise InternalError("Failed to set transaction mode: transaction is already began")
+        self.tx_mode = ydb_isolation_settings[0]
+        self.interactive_transaction = ydb_isolation_settings[1]
+
+    def get_isolation_level(self) -> str:
+        if self.tx_mode.name == ydb.SerializableReadWrite().name:
+            if self.interactive_transaction:
+                return IsolationLevel.SERIALIZABLE
+            else:
+                return IsolationLevel.AUTOCOMMIT
+        elif self.tx_mode.name == ydb.OnlineReadOnly().name:
+            if self.tx_mode.settings.allow_inconsistent_reads:
+                return IsolationLevel.ONLINE_READONLY_INCONSISTENT
+            else:
+                return IsolationLevel.ONLINE_READONLY
+        elif self.tx_mode.name == ydb.StaleReadOnly().name:
+            return IsolationLevel.STALE_READONLY
+        elif self.tx_mode.name == ydb.SnapshotReadOnly().name:
+            return IsolationLevel.SNAPSHOT_READONLY
+        else:
+            raise NotSupportedError(f"{self.tx_mode.name} is not supported")
+
+    def begin(self):
+        if not self.session.initialized():
+            raise InternalError("Failed to begin transaction: session closed")
+        self.transaction = None
+        if self.interactive_transaction:
+            self.transaction = self.session.transaction(self.tx_mode)
+            self.transaction.begin()
+
     def commit(self):
-        pass
+        if self.transaction and self.transaction.tx_id:
+            self.transaction.commit()
 
     def rollback(self):
-        pass
+        if self.transaction and self.transaction.tx_id:
+            self.transaction.rollback()
 
     def close(self):
-        if self.pool:
-            self.pool.stop()
-        if self.driver:
-            self.driver.stop()
+        self._delete_session()
+        self._stop_driver()
 
     @staticmethod
-    def _create_driver(endpoint, database, **conn_kwargs):
-        # TODO: add cache for initialized drivers/pools?
-        driver_config = ydb.DriverConfig(
-            endpoint,
-            database=database,
-            table_client_settings=ydb.TableClientSettings()
+    def _get_table_client_settings() -> ydb.TableClientSettings:
+        return (
+            ydb.TableClientSettings()
             .with_native_date_in_result_sets(True)
             .with_native_datetime_in_result_sets(True)
             .with_native_timestamp_in_result_sets(True)
             .with_native_interval_in_result_sets(True)
-            .with_native_json_in_result_sets(True),
+            .with_native_json_in_result_sets(True)
+        )
+
+    def _create_driver(self, **conn_kwargs):
+        # TODO: add cache for initialized drivers/pools?
+        driver_config = ydb.DriverConfig(
+            endpoint=self.endpoint,
+            database=self.database,
+            table_client_settings=self.table_client_settings,
             **conn_kwargs,
         )
         driver = ydb.Driver(driver_config)
@@ -68,3 +128,16 @@ class Connection:
             driver.stop()
             raise InterfaceError(f"Failed to connect to YDB, details {driver.discovery_debug_details()}") from e
         return driver
+
+    def _stop_driver(self):
+        self.driver.stop()
+
+    def _create_session(self) -> ydb.BaseSession:
+        session = ydb.Session(self.driver, self.table_client_settings)
+        session.create()
+        return session
+
+    def _delete_session(self):
+        if self.session.initialized():
+            self.rollback()
+            self.session.delete()

--- a/ydb_sqlalchemy/dbapi/cursor.py
+++ b/ydb_sqlalchemy/dbapi/cursor.py
@@ -33,16 +33,16 @@ class YdbQuery:
 
 
 class Cursor(object):
-    def __init__(self, connection):
+    def __init__(self, connection, transaction: Optional[ydb.BaseTxContext] = None):
         self.connection = connection
+        self.session: ydb.Session = self.connection.session
+        self.transaction = transaction
         self.description = None
         self.arraysize = 1
         self.rows = None
         self._rows_prefetched = None
 
     def execute(self, operation: YdbQuery, parameters: Optional[Mapping[str, Any]] = None):
-        self.description = None
-
         if operation.is_ddl or not operation.parameters_types:
             query = operation.yql_text
             is_ddl = operation.is_ddl
@@ -50,46 +50,7 @@ class Cursor(object):
             query = ydb.DataQuery(operation.yql_text, operation.parameters_types)
             is_ddl = operation.is_ddl
 
-        logger.info("execute sql: %s, params: %s", query, parameters)
-
-        def _execute_in_pool(cli: ydb.Session):
-            try:
-                if is_ddl:
-                    return cli.execute_scheme(query)
-
-                prepared_query = query
-                if isinstance(query, str) and parameters:
-                    prepared_query = cli.prepare(query)
-
-                return cli.transaction().execute(prepared_query, parameters, commit_tx=True)
-            except (ydb.issues.AlreadyExists, ydb.issues.PreconditionFailed) as e:
-                raise IntegrityError(e.message, e.issues, e.status) from e
-            except (ydb.issues.Unsupported, ydb.issues.Unimplemented) as e:
-                raise NotSupportedError(e.message, e.issues, e.status) from e
-            except (ydb.issues.BadRequest, ydb.issues.SchemeError) as e:
-                raise ProgrammingError(e.message, e.issues, e.status) from e
-            except (
-                ydb.issues.TruncatedResponseError,
-                ydb.issues.ConnectionError,
-                ydb.issues.Aborted,
-                ydb.issues.Unavailable,
-                ydb.issues.Overloaded,
-                ydb.issues.Undetermined,
-                ydb.issues.Timeout,
-                ydb.issues.Cancelled,
-                ydb.issues.SessionBusy,
-                ydb.issues.SessionExpired,
-                ydb.issues.SessionPoolEmpty,
-            ) as e:
-                raise OperationalError(e.message, e.issues, e.status) from e
-            except ydb.issues.GenericError as e:
-                raise DataError(e.message, e.issues, e.status) from e
-            except ydb.issues.InternalError as e:
-                raise InternalError(e.message, e.issues, e.status) from e
-            except ydb.Error as e:
-                raise DatabaseError(e.message, e.issues, e.status) from e
-
-        chunks = self.connection.pool.retry_operation_sync(_execute_in_pool)
+        chunks = self._execute(query, parameters, is_ddl)
         rows = self._rows_iterable(chunks)
         # Prefetch the description:
         try:
@@ -102,6 +63,50 @@ class Cursor(object):
             rows = itertools.chain(self.rows, rows)
 
         self.rows = rows
+
+    def _execute(self, query: Union[ydb.DataQuery, str], parameters: Optional[Mapping[str, Any]], is_ddl: bool):
+        self.description = None
+        logger.info("execute sql: %s, params: %s", query, parameters)
+        try:
+            if is_ddl:
+                return ydb.retry_operation_sync(lambda: self.session.execute_scheme(query))
+
+            prepared_query = query
+            if isinstance(query, str) and parameters:
+                prepared_query = self.session.prepare(query)
+
+            if not self.transaction:
+                return ydb.retry_operation_sync(
+                    lambda: self.session.transaction().execute(prepared_query, parameters, commit_tx=True)
+                )
+            else:
+                return self.transaction.execute(prepared_query, parameters)
+        except (ydb.issues.AlreadyExists, ydb.issues.PreconditionFailed) as e:
+            raise IntegrityError(e.message, e.issues, e.status) from e
+        except (ydb.issues.Unsupported, ydb.issues.Unimplemented) as e:
+            raise NotSupportedError(e.message, e.issues, e.status) from e
+        except (ydb.issues.BadRequest, ydb.issues.SchemeError) as e:
+            raise ProgrammingError(e.message, e.issues, e.status) from e
+        except (
+            ydb.issues.TruncatedResponseError,
+            ydb.issues.ConnectionError,
+            ydb.issues.Aborted,
+            ydb.issues.Unavailable,
+            ydb.issues.Overloaded,
+            ydb.issues.Undetermined,
+            ydb.issues.Timeout,
+            ydb.issues.Cancelled,
+            ydb.issues.SessionBusy,
+            ydb.issues.SessionExpired,
+            ydb.issues.SessionPoolEmpty,
+        ) as e:
+            raise OperationalError(e.message, e.issues, e.status) from e
+        except ydb.issues.GenericError as e:
+            raise DataError(e.message, e.issues, e.status) from e
+        except ydb.issues.InternalError as e:
+            raise InternalError(e.message, e.issues, e.status) from e
+        except ydb.Error as e:
+            raise DatabaseError(e.message, e.issues, e.status) from e
 
     def _rows_iterable(self, chunks_iterable):
         try:

--- a/ydb_sqlalchemy/sqlalchemy/__init__.py
+++ b/ydb_sqlalchemy/sqlalchemy/__init__.py
@@ -538,9 +538,23 @@ class YqlDialect(StrCompileDialect):
         # TODO: implement me
         return []
 
-    def do_commit(self, dbapi_connection) -> None:
-        # TODO: needs to implement?
-        pass
+    def set_isolation_level(self, dbapi_connection: dbapi.Connection, level: str) -> None:
+        dbapi_connection.set_isolation_level(level)
+
+    def get_default_isolation_level(self, dbapi_conn: dbapi.Connection) -> str:
+        return dbapi.IsolationLevel.AUTOCOMMIT
+
+    def get_isolation_level(self, dbapi_connection: dbapi.Connection) -> str:
+        return dbapi_connection.get_isolation_level()
+
+    def do_begin(self, dbapi_connection: dbapi.Connection) -> None:
+        dbapi_connection.begin()
+
+    def do_rollback(self, dbapi_connection: dbapi.Connection) -> None:
+        dbapi_connection.rollback()
+
+    def do_commit(self, dbapi_connection: dbapi.Connection) -> None:
+        dbapi_connection.commit()
 
     def _format_variables(
         self,


### PR DESCRIPTION
### Description
This PR contains two major changes.

**Replacing the ydb session pool with one ydb session**
SQLAlchemy uses its own ConnectionPool with a priority queue. Connection is the unit of parallelism of this library, which is used for managing transactions and making queries, just like the ydb.Session do, so it must be exactly one session per connection. This session should be closed before the closing of the connection.

**Implementing transactions**
SQLAlchemy providers an ability to configure an isolation level of a transaction and to begin an interactive transaction, as well as commiting and rollbacking them. All now presented isolations level are implemented.