### PR TITLE
Add basic JSON support

### DIFF
--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -1,3 +1,5 @@
+import ctypes
+
 import pytest
 import sqlalchemy as sa
 import sqlalchemy.testing.suite.test_types
@@ -65,6 +67,7 @@ from sqlalchemy.testing.suite.test_types import (
 )
 from sqlalchemy.testing.suite.test_types import DateTimeTest as _DateTimeTest
 from sqlalchemy.testing.suite.test_types import IntegerTest as _IntegerTest
+from sqlalchemy.testing.suite.test_types import JSONTest as _JSONTest
 from sqlalchemy.testing.suite.test_types import NativeUUIDTest as _NativeUUIDTest
 from sqlalchemy.testing.suite.test_types import NumericTest as _NumericTest
 from sqlalchemy.testing.suite.test_types import StringTest as _StringTest
@@ -428,6 +431,25 @@ class TimestampMicrosecondsTest(_TimestampMicrosecondsTest):
 @pytest.mark.skip("unsupported Time data type")
 class TimeTest(_TimeTest):
     pass
+
+
+class JSONTest(_JSONTest):
+    @classmethod
+    def define_tables(cls, metadata):
+        Table(
+            "data_table",
+            metadata,
+            Column("id", Integer, primary_key=True, default=1),
+            Column("name", String(30), primary_key=True, nullable=False),
+            Column("data", cls.datatype, nullable=False),
+            Column("nulldata", cls.datatype(none_as_null=True)),
+        )
+
+    def _json_value_insert(self, connection, datatype, value, data_element):
+        if datatype == "float" and value is not None:
+            # As python's float is stored as C double, it needs to be shrank
+            value = ctypes.c_float(value).value
+        return super()._json_value_insert(connection, datatype, value, data_element)
 
 
 class StringTest(_StringTest):

--- a/ydb_sqlalchemy/dbapi/connection.py
+++ b/ydb_sqlalchemy/dbapi/connection.py
@@ -149,7 +149,7 @@ class Connection:
             .with_native_datetime_in_result_sets(True)
             .with_native_timestamp_in_result_sets(True)
             .with_native_interval_in_result_sets(True)
-            .with_native_json_in_result_sets(True)
+            .with_native_json_in_result_sets(False)
         )
 
     def _create_driver(self):

--- a/ydb_sqlalchemy/sqlalchemy/json.py
+++ b/ydb_sqlalchemy/sqlalchemy/json.py
@@ -1,0 +1,34 @@
+from typing import Union
+
+from sqlalchemy import types as sqltypes
+
+
+class YqlJSON(sqltypes.JSON):
+    class YqlJSONPathType(sqltypes.JSON.JSONPathType):
+        def _format_value(self, value: tuple[Union[str, int]]) -> str:
+            path = "/"
+            for elem in value:
+                path += f"/{elem}"
+            return path
+
+        def bind_processor(self, dialect):
+            super_proc = self.string_bind_processor(dialect)
+
+            def process(value: tuple[Union[str, int]]):
+                value = self._format_value(value)
+                if super_proc:
+                    value = super_proc(value)
+                return value
+
+            return process
+
+        def literal_processor(self, dialect):
+            super_proc = self.string_literal_processor(dialect)
+
+            def process(value: tuple[Union[str, int]]):
+                value = self._format_value(value)
+                if super_proc:
+                    value = super_proc(value)
+                return value
+
+            return process

--- a/ydb_sqlalchemy/sqlalchemy/json.py
+++ b/ydb_sqlalchemy/sqlalchemy/json.py
@@ -1,11 +1,11 @@
-from typing import Union
+from typing import Tuple, Union
 
 from sqlalchemy import types as sqltypes
 
 
 class YqlJSON(sqltypes.JSON):
     class YqlJSONPathType(sqltypes.JSON.JSONPathType):
-        def _format_value(self, value: tuple[Union[str, int]]) -> str:
+        def _format_value(self, value: Tuple[Union[str, int]]) -> str:
             path = "/"
             for elem in value:
                 path += f"/{elem}"
@@ -14,7 +14,7 @@ class YqlJSON(sqltypes.JSON):
         def bind_processor(self, dialect):
             super_proc = self.string_bind_processor(dialect)
 
-            def process(value: tuple[Union[str, int]]):
+            def process(value: Tuple[Union[str, int]]):
                 value = self._format_value(value)
                 if super_proc:
                     value = super_proc(value)
@@ -25,7 +25,7 @@ class YqlJSON(sqltypes.JSON):
         def literal_processor(self, dialect):
             super_proc = self.string_literal_processor(dialect)
 
-            def process(value: tuple[Union[str, int]]):
+            def process(value: Tuple[Union[str, int]]):
                 value = self._format_value(value)
                 if super_proc:
                     value = super_proc(value)

--- a/ydb_sqlalchemy/sqlalchemy/requirements.py
+++ b/ydb_sqlalchemy/sqlalchemy/requirements.py
@@ -4,6 +4,10 @@ from sqlalchemy.testing.requirements import SuiteRequirements
 
 class Requirements(SuiteRequirements):
     @property
+    def json_type(self):
+        return exclusions.open()
+
+    @property
     def array_type(self):
         return exclusions.closed()
 

--- a/ydb_sqlalchemy/sqlalchemy/types.py
+++ b/ydb_sqlalchemy/sqlalchemy/types.py
@@ -3,6 +3,8 @@ from typing import Any, Mapping, Type, Union
 from sqlalchemy import ARRAY, ColumnElement, exc, types
 from sqlalchemy.sql import type_api
 
+from .json import YqlJSON  # noqa: F401
+
 
 class UInt64(types.Integer):
     __visit_name__ = "uint64"


### PR DESCRIPTION
### Problem
All modern SQL databases implements JSON type field. It supports special column type and a batch of special operation with JSON such as indexing and casting.
SQLAlchemy also supports JSON field and operations with it, so it needs to be implemented in dialect.

### In this PR
In this PR the basic JSON type is implemented, also I created a YQLJson type for future extending with special YQL specific things such as Yson::Equals.

### Example
This SQLAlchemy statement
```
sa.select(table.c.json_field[('my', 'list', 5)]).where(table.c.json_field['key'].as_string() == 'test')
```
converts to 
```
SELECT Yson::ConvertTo(Yson::Ypath(json_field, '/my/list/5'), Optional<Json>))
FROM table
WHERE 
    Yson::ConvertTo(json_field['key'], Optional<Utf8>)) == 'test'
```