### PR TITLE
Feature: Secondary indexes

### DIFF
--- a/ydb_sqlalchemy/sqlalchemy/__init__.py
+++ b/ydb_sqlalchemy/sqlalchemy/__init__.py
@@ -466,7 +466,7 @@ class YqlDDLCompiler(DDLCompiler):
 
         text = f"ALTER TABLE {table_name} ADD INDEX {index_name} GLOBAL"
 
-        text += " SYNC " if not ydb_opts.get("async", False) else " ASYNC"
+        text += " SYNC" if not ydb_opts.get("async", False) else " ASYNC"
 
         columns = {self.preparer.format_column(col) for col in index.columns.values()}
         cover_columns = {

--- a/ydb_sqlalchemy/sqlalchemy/__init__.py
+++ b/ydb_sqlalchemy/sqlalchemy/__init__.py
@@ -459,7 +459,7 @@ class YqlDDLCompiler(DDLCompiler):
         self._verify_index_table(index)
 
         if index.name is None:
-            raise CompileError("ADD INDEX requires that the index have a name")
+            raise CompileError("ADD INDEX requires that the index has a name")
 
         table_name = self.preparer.format_table(index.table)
         index_name = self._prepared_index_name(index)

--- a/ydb_sqlalchemy/sqlalchemy/__init__.py
+++ b/ydb_sqlalchemy/sqlalchemy/__init__.py
@@ -235,6 +235,9 @@ class ParametrizedFunction(functions.Function):
 class YqlCompiler(StrSQLCompiler):
     compound_keywords = COMPOUND_KEYWORDS
 
+    def get_from_hint_text(self, table, text):
+        return text
+
     def render_bind_cast(self, type_, dbapi_type, sqltext):
         pass
 

--- a/ydb_sqlalchemy/sqlalchemy/requirements.py
+++ b/ydb_sqlalchemy/sqlalchemy/requirements.py
@@ -46,6 +46,7 @@ class Requirements(SuiteRequirements):
 
     @property
     def index_reflection(self):
+        # Reflection supported with limits
         return exclusions.closed()
 
     @property


### PR DESCRIPTION
## Description
YDB supports secondary indexes over the table, which may be used to optimize the selection of data.

## In this PR 
This PR contains the dialect features to declare and usage of YDB Secondary Indexes within SQLAlchemy `Index` and `hints`.

## Example
### Declaration
```python
sa.Index("my_index", table.c.c2, ydb_async=True, ydb_cover=["c3"])
```
is rendered as
```sql
ALTER TABLE table ADD INDEX my_index GLOBAL ASYNC ON (c2) COVER (c3);
```

### Usage
```python
sa.select(
    sa.column(table.c.c1)
)
.select_from(table)
.where(sa.column(table.c.c2) == 1)
.with_hint(table, "VIEW `my_index`")
```
is rendered as
```sql
SELECT c1
FROM table VIEW `my_index`
WHERE c2 == 1
```
