### PR TITLE
Implement ScanQuery

### DIFF
--- a/ydb_sqlalchemy/dbapi/cursor.py
+++ b/ydb_sqlalchemy/dbapi/cursor.py
@@ -5,7 +5,17 @@ import hashlib
 import itertools
 import logging
 import posixpath
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
+from collections.abc import AsyncIterator
+from typing import (
+    Any,
+    Dict,
+    Generator,
+    List,
+    Mapping,
+    Optional,
+    Sequence,
+    Union,
+)
 
 import ydb
 import ydb.aio
@@ -77,14 +87,18 @@ def _handle_ydb_errors(func):
 class Cursor:
     def __init__(
         self,
+        driver: Union[ydb.Driver, ydb.aio.Driver],
         session_pool: Union[ydb.SessionPool, ydb.aio.SessionPool],
         tx_mode: ydb.AbstractTransactionModeBuilder,
         tx_context: Optional[ydb.BaseTxContext] = None,
+        use_scan_query: bool = False,
         table_path_prefix: str = "",
     ):
+        self.driver = driver
         self.session_pool = session_pool
         self.tx_mode = tx_mode
         self.tx_context = tx_context
+        self.use_scan_query = use_scan_query
         self.description = None
         self.arraysize = 1
         self.rows = None
@@ -120,6 +134,8 @@ class Cursor:
         logger.info("execute sql: %s, params: %s", query, parameters)
         if operation.is_ddl:
             chunks = self._execute_ddl(query)
+        elif self.use_scan_query:
+            chunks = self._execute_scan_query(query, parameters)
         else:
             chunks = self._execute_dml(query, parameters)
 
@@ -163,6 +179,21 @@ class Cursor:
         yql_with_params = yql_text + "".join([k + str(v) for k, v in sorted_parameters])
         name = hashlib.sha256(yql_with_params.encode("utf-8")).hexdigest()
         return ydb.DataQuery(yql_text, parameters_types, name=name)
+
+    @_handle_ydb_errors
+    def _execute_scan_query(
+        self, query: Union[ydb.DataQuery, str], parameters: Optional[Mapping[str, Any]] = None
+    ) -> Generator[ydb.convert.ResultSet, None, None]:
+        prepared_query = query
+        if isinstance(query, str) and parameters:
+            prepared_query: ydb.DataQuery = self._retry_operation_in_pool(self._prepare, query)
+
+        if isinstance(query, str):
+            scan_query = ydb.ScanQuery(query, None)
+        else:
+            scan_query = ydb.ScanQuery(prepared_query.yql_text, prepared_query.parameters_types)
+
+        return self._execute_scan_query_in_driver(scan_query, parameters)
 
     @_handle_ydb_errors
     def _execute_dml(
@@ -218,6 +249,15 @@ class Cursor:
         parameters: Optional[Mapping[str, Any]],
     ) -> ydb.convert.ResultSets:
         return session.transaction(tx_mode).execute(prepared_query, parameters, commit_tx=True)
+
+    def _execute_scan_query_in_driver(
+        self,
+        scan_query: ydb.ScanQuery,
+        parameters: Optional[Mapping[str, Any]],
+    ) -> Generator[ydb.convert.ResultSet, None, None]:
+        chunk: ydb.ScanQueryResult
+        for chunk in self.driver.table_client.scan_query(scan_query, parameters):
+            yield chunk.result_set
 
     def _run_operation_in_tx(self, callee: collections.abc.Callable, *args, **kwargs):
         return callee(self.tx_context, *args, **kwargs)
@@ -327,6 +367,21 @@ class AsyncCursor(Cursor):
         parameters: Optional[Mapping[str, Any]],
     ) -> ydb.convert.ResultSets:
         return await session.transaction(tx_mode).execute(prepared_query, parameters, commit_tx=True)
+
+    def _execute_scan_query_in_driver(
+        self,
+        scan_query: ydb.ScanQuery,
+        parameters: Optional[Mapping[str, Any]],
+    ) -> Generator[ydb.convert.ResultSet, None, None]:
+        iterator: AsyncIterator[ydb.ScanQueryResult] = self._await(
+            self.driver.table_client.scan_query(scan_query, parameters)
+        )
+        while True:
+            try:
+                result = self._await(iterator.__anext__())
+                yield result.result_set
+            except StopAsyncIteration:
+                break
 
     def _run_operation_in_tx(self, callee: collections.abc.Coroutine, *args, **kwargs):
         return self._await(callee(self.tx_context, *args, **kwargs))

--- a/ydb_sqlalchemy/dbapi/cursor.py
+++ b/ydb_sqlalchemy/dbapi/cursor.py
@@ -304,7 +304,7 @@ class Cursor:
         return self.execute(script)
 
     def fetchone(self):
-        return next(self.rows or [], None)
+        return next(self.rows or iter([]), None)
 
     def fetchmany(self, size=None):
         return list(itertools.islice(self.rows, size or self.arraysize))

--- a/ydb_sqlalchemy/sqlalchemy/__init__.py
+++ b/ydb_sqlalchemy/sqlalchemy/__init__.py
@@ -560,7 +560,7 @@ def _get_column_info(t):
 
 class YdbScanQueryCharacteristic(characteristics.ConnectionCharacteristic):
     def reset_characteristic(self, dialect: "YqlDialect", dbapi_connection: dbapi.Connection) -> None:
-        dialect.reset_isolation_level(dbapi_connection)
+        dialect.reset_ydb_scan_query(dbapi_connection)
 
     def set_characteristic(self, dialect: "YqlDialect", dbapi_connection: dbapi.Connection, value: bool) -> None:
         dialect.set_ydb_scan_query(dbapi_connection, value)
@@ -745,7 +745,7 @@ class YqlDialect(StrCompileDialect):
     def set_ydb_scan_query(self, dbapi_connection: dbapi.Connection, value: bool) -> None:
         dbapi_connection.set_ydb_scan_query(value)
 
-    def reset_isolation_level(self, dbapi_connection: dbapi.Connection):
+    def reset_ydb_scan_query(self, dbapi_connection: dbapi.Connection):
         self.set_ydb_scan_query(dbapi_connection, False)
 
     def get_ydb_scan_query(self, dbapi_connection: dbapi.Connection) -> str:


### PR DESCRIPTION
## Problem
For some reasons user may want to retrieve large amount of data from the table. Now it is possible only through the online read only transaction and it leads to TruncatedResponseError. Moreover such approach affects OLTP queries.

The YDB has special mechanism to do OLAP queries using snapshots called ScanQuery.

## In this PR
In this PR I add an execution option to enable ScanQuery mode.

## Example
```python

with engine.begin() as connection:
    connection.execution_options(ydb_scan_query=True)  # Enable ScanQuery mode on connection
    cursor = connection.execute(sa.select(table))  # Fetch rows using ScanQuery
    
    for chunk in cursor.partitions(1000):  # gRPC stream iteration supported
        print(chunk)
```