### PR TITLE
Enable compilation query cache

### DIFF
--- a/ydb_sqlalchemy/sqlalchemy/__init__.py
+++ b/ydb_sqlalchemy/sqlalchemy/__init__.py
@@ -564,7 +564,7 @@ class YqlDialect(StrCompileDialect):
     supports_alter = False
     max_identifier_length = 63
     supports_sane_rowcount = False
-    supports_statement_cache = False
+    supports_statement_cache = True
 
     supports_native_enum = False
     supports_native_boolean = True
@@ -829,7 +829,7 @@ class YqlDialect(StrCompileDialect):
 class AsyncYqlDialect(YqlDialect):
     driver = "ydb_async"
     is_async = True
-    supports_statement_cache = False
+    supports_statement_cache = True
 
     def connect(self, *cargs, **cparams):
         return self.loaded_dbapi.async_connect(*cargs, **cparams)

--- a/ydb_sqlalchemy/sqlalchemy/dml.py
+++ b/ydb_sqlalchemy/sqlalchemy/dml.py
@@ -5,6 +5,7 @@ class Upsert(sa.sql.Insert):
     __visit_name__ = "upsert"
     _propagate_attrs = {"compile_state_plugin": "yql"}
     stringify_dialect = "yql"
+    inherit_cache = False
 
 
 @sa.sql.base.CompileState.plugin_for("yql", "upsert")

--- a/ydb_sqlalchemy/sqlalchemy/types.py
+++ b/ydb_sqlalchemy/sqlalchemy/types.py
@@ -43,11 +43,16 @@ class ListType(ARRAY):
     __visit_name__ = "list_type"
 
 
+class HashableDict(dict):
+    def __hash__(self):
+        return hash(tuple(self.items()))
+
+
 class StructType(types.TypeEngine[Mapping[str, Any]]):
     __visit_name__ = "struct_type"
 
     def __init__(self, fields_types: Mapping[str, Union[Type[types.TypeEngine], Type[types.TypeDecorator]]]):
-        self.fields_types = fields_types
+        self.fields_types = HashableDict(dict(sorted(fields_types.items())))
 
     @property
     def python_type(self):


### PR DESCRIPTION
## Description
SQLAlchemy supports caching of compiled queries, which may increase performance.

## In this PR
Enable statements caching