### PR TITLE
Use "Datetime" ydb type for sa.DATETIME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+* sqlalchemy's DATETIME type now rendered as YDB's Datetime instead of Timestamp
+
 ## 0.0.1b19 ##
 * Do not use set for columns in index, use dict (preserve order)
 

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -260,7 +260,7 @@ class TestTypes(TablesTest):
         )
 
         result = connection.execute(stmt).fetchone()
-        assert result == (b"Datetime", b"Datetime", b"Timestamp")
+        assert result == (b"Timestamp", b"Datetime", b"Timestamp")
 
     def test_datetime_types_timezone(self, connection: sa.Connection):
         table = self.tables.test_datetime_types

--- a/test/test_core.py
+++ b/test/test_core.py
@@ -253,6 +253,16 @@ class TestTypes(TablesTest):
         assert result == (b"Uint8", b"Uint16", b"Uint32", b"Uint64", b"Int8", b"Int16", b"Int32", b"Int64")
 
     def test_datetime_types(self, connection: sa.Connection):
+        stmt = sa.Select(
+            sa.func.FormatType(sa.func.TypeOf(sa.bindparam("p_datetime", datetime.datetime.now(), sa.DateTime))),
+            sa.func.FormatType(sa.func.TypeOf(sa.bindparam("p_DATETIME", datetime.datetime.now(), sa.DATETIME))),
+            sa.func.FormatType(sa.func.TypeOf(sa.bindparam("p_TIMESTAMP", datetime.datetime.now(), sa.TIMESTAMP))),
+        )
+
+        result = connection.execute(stmt).fetchone()
+        assert result == (b"Timestamp", b"Datetime", b"Timestamp")
+
+    def test_datetime_types_timezone(self, connection: sa.Connection):
         table = self.tables.test_datetime_types
 
         now_dt = datetime.datetime.now()

--- a/ydb_sqlalchemy/sqlalchemy/__init__.py
+++ b/ydb_sqlalchemy/sqlalchemy/__init__.py
@@ -132,7 +132,13 @@ class YqlTypeCompiler(StrSQLTypeCompiler):
     def visit_BLOB(self, type_: sa.BLOB, **kw):
         return "String"
 
-    def visit_DATETIME(self, type_: sa.TIMESTAMP, **kw):
+    def visit_datetime(self, type_: sa.TIMESTAMP, **kw):
+        return self.visit_TIMESTAMP(type_, **kw)
+
+    def visit_DATETIME(self, type_: sa.DATETIME, **kw):
+        return "DateTime"
+
+    def visit_TIMESTAMP(self, type_: sa.TIMESTAMP, **kw):
         return "Timestamp"
 
     def visit_list_type(self, type_: types.ListType, **kw):
@@ -193,7 +199,10 @@ class YqlTypeCompiler(StrSQLTypeCompiler):
         elif isinstance(type_, types.YqlJSON.YqlJSONPathType):
             ydb_type = ydb.PrimitiveType.Utf8
         # Json
-
+        elif isinstance(type_, sa.DATETIME):
+            ydb_type = ydb.PrimitiveType.Datetime
+        elif isinstance(type_, sa.TIMESTAMP):
+            ydb_type = ydb.PrimitiveType.Timestamp
         elif isinstance(type_, sa.DateTime):
             ydb_type = ydb.PrimitiveType.Timestamp
         elif isinstance(type_, sa.Date):
@@ -610,7 +619,9 @@ class YqlDialect(StrCompileDialect):
     colspecs = {
         sa.types.JSON: types.YqlJSON,
         sa.types.JSON.JSONPathType: types.YqlJSON.YqlJSONPathType,
-        sa.types.DateTime: types.YqlDateTime,
+        sa.types.DateTime: types.YqlTimestamp,
+        sa.types.DATETIME: types.YqlDateTime,
+        sa.types.TIMESTAMP: types.YqlTimestamp,
     }
 
     connection_characteristics = util.immutabledict(

--- a/ydb_sqlalchemy/sqlalchemy/__init__.py
+++ b/ydb_sqlalchemy/sqlalchemy/__init__.py
@@ -132,8 +132,8 @@ class YqlTypeCompiler(StrSQLTypeCompiler):
     def visit_BLOB(self, type_: sa.BLOB, **kw):
         return "String"
 
-    def visit_datetime(self, type_: sa.DATETIME, **kw):
-        return self.visit_DATETIME(type_, **kw)
+    def visit_datetime(self, type_: sa.TIMESTAMP, **kw):
+        return self.visit_TIMESTAMP(type_, **kw)
 
     def visit_DATETIME(self, type_: sa.DATETIME, **kw):
         return "DateTime"
@@ -204,7 +204,7 @@ class YqlTypeCompiler(StrSQLTypeCompiler):
         elif isinstance(type_, sa.TIMESTAMP):
             ydb_type = ydb.PrimitiveType.Timestamp
         elif isinstance(type_, sa.DateTime):
-            ydb_type = ydb.PrimitiveType.Datetime
+            ydb_type = ydb.PrimitiveType.Timestamp
         elif isinstance(type_, sa.Date):
             ydb_type = ydb.PrimitiveType.Date
         elif isinstance(type_, sa.BINARY):
@@ -619,7 +619,7 @@ class YqlDialect(StrCompileDialect):
     colspecs = {
         sa.types.JSON: types.YqlJSON,
         sa.types.JSON.JSONPathType: types.YqlJSON.YqlJSONPathType,
-        sa.types.DateTime: types.YqlDateTime,
+        sa.types.DateTime: types.YqlTimestamp,  # Because YDB's DateTime doesn't store microseconds
         sa.types.DATETIME: types.YqlDateTime,
         sa.types.TIMESTAMP: types.YqlTimestamp,
     }

--- a/ydb_sqlalchemy/sqlalchemy/__init__.py
+++ b/ydb_sqlalchemy/sqlalchemy/__init__.py
@@ -132,8 +132,8 @@ class YqlTypeCompiler(StrSQLTypeCompiler):
     def visit_BLOB(self, type_: sa.BLOB, **kw):
         return "String"
 
-    def visit_datetime(self, type_: sa.TIMESTAMP, **kw):
-        return self.visit_TIMESTAMP(type_, **kw)
+    def visit_datetime(self, type_: sa.DATETIME, **kw):
+        return self.visit_DATETIME(type_, **kw)
 
     def visit_DATETIME(self, type_: sa.DATETIME, **kw):
         return "DateTime"
@@ -204,7 +204,7 @@ class YqlTypeCompiler(StrSQLTypeCompiler):
         elif isinstance(type_, sa.TIMESTAMP):
             ydb_type = ydb.PrimitiveType.Timestamp
         elif isinstance(type_, sa.DateTime):
-            ydb_type = ydb.PrimitiveType.Timestamp
+            ydb_type = ydb.PrimitiveType.Datetime
         elif isinstance(type_, sa.Date):
             ydb_type = ydb.PrimitiveType.Date
         elif isinstance(type_, sa.BINARY):
@@ -549,7 +549,7 @@ COLUMN_TYPES = {
     ydb.PrimitiveType.Yson: sa.TEXT,
     ydb.PrimitiveType.Date: sa.DATE,
     ydb.PrimitiveType.Datetime: sa.DATETIME,
-    ydb.PrimitiveType.Timestamp: sa.DATETIME,
+    ydb.PrimitiveType.Timestamp: sa.TIMESTAMP,
     ydb.PrimitiveType.Interval: sa.INTEGER,
     ydb.PrimitiveType.Bool: sa.BOOLEAN,
     ydb.PrimitiveType.DyNumber: sa.TEXT,
@@ -619,7 +619,7 @@ class YqlDialect(StrCompileDialect):
     colspecs = {
         sa.types.JSON: types.YqlJSON,
         sa.types.JSON.JSONPathType: types.YqlJSON.YqlJSONPathType,
-        sa.types.DateTime: types.YqlTimestamp,
+        sa.types.DateTime: types.YqlDateTime,
         sa.types.DATETIME: types.YqlDateTime,
         sa.types.TIMESTAMP: types.YqlTimestamp,
     }

--- a/ydb_sqlalchemy/sqlalchemy/datetime_types.py
+++ b/ydb_sqlalchemy/sqlalchemy/datetime_types.py
@@ -11,11 +11,11 @@ class YqlTimestamp(sqltypes.DateTime):
         def process(value: Optional[datetime.datetime]) -> Optional[datetime.datetime]:
             if value is None:
                 return None
+            if not self.timezone:
+                return value
             return value.replace(tzinfo=datetime.timezone.utc)
 
-        if self.timezone:
-            return process
-        return None
+        return process
 
 
 class YqlDateTime(YqlTimestamp):
@@ -23,6 +23,8 @@ class YqlDateTime(YqlTimestamp):
         def process(value: Optional[datetime.datetime]) -> Optional[int]:
             if value is None:
                 return None
+            if not self.timezone:  # if timezone is disabled, consider it as utc
+                value = value.replace(tzinfo=datetime.timezone.utc)
             return int(value.timestamp())
 
         return process

--- a/ydb_sqlalchemy/sqlalchemy/datetime_types.py
+++ b/ydb_sqlalchemy/sqlalchemy/datetime_types.py
@@ -6,7 +6,7 @@ from sqlalchemy import types as sqltypes
 from sqlalchemy.sql.type_api import _BindProcessorType, _ResultProcessorType
 
 
-class YqlTimestamp(sqltypes.DateTime):
+class YqlTimestamp(sqltypes.TIMESTAMP):
     def result_processor(self, dialect: Dialect, coltype: str) -> Optional[_ResultProcessorType[datetime.datetime]]:
         def process(value: Optional[datetime.datetime]) -> Optional[datetime.datetime]:
             if value is None:
@@ -18,7 +18,7 @@ class YqlTimestamp(sqltypes.DateTime):
         return process
 
 
-class YqlDateTime(YqlTimestamp):
+class YqlDateTime(YqlTimestamp, sqltypes.DATETIME):
     def bind_processor(self, dialect: Dialect) -> Optional[_BindProcessorType[datetime.datetime]]:
         def process(value: Optional[datetime.datetime]) -> Optional[int]:
             if value is None:

--- a/ydb_sqlalchemy/sqlalchemy/datetime_types.py
+++ b/ydb_sqlalchemy/sqlalchemy/datetime_types.py
@@ -3,10 +3,10 @@ from typing import Optional
 
 from sqlalchemy import Dialect
 from sqlalchemy import types as sqltypes
-from sqlalchemy.sql.type_api import _ResultProcessorType
+from sqlalchemy.sql.type_api import _BindProcessorType, _ResultProcessorType
 
 
-class YqlDateTime(sqltypes.DateTime):
+class YqlTimestamp(sqltypes.DateTime):
     def result_processor(self, dialect: Dialect, coltype: str) -> Optional[_ResultProcessorType[datetime.datetime]]:
         def process(value: Optional[datetime.datetime]) -> Optional[datetime.datetime]:
             if value is None:
@@ -16,3 +16,13 @@ class YqlDateTime(sqltypes.DateTime):
         if self.timezone:
             return process
         return None
+
+
+class YqlDateTime(YqlTimestamp):
+    def bind_processor(self, dialect: Dialect) -> Optional[_BindProcessorType[datetime.datetime]]:
+        def process(value: Optional[datetime.datetime]) -> Optional[int]:
+            if value is None:
+                return None
+            return int(value.timestamp())
+
+        return process

--- a/ydb_sqlalchemy/sqlalchemy/types.py
+++ b/ydb_sqlalchemy/sqlalchemy/types.py
@@ -3,7 +3,7 @@ from typing import Any, Mapping, Type, Union
 from sqlalchemy import ARRAY, ColumnElement, exc, types
 from sqlalchemy.sql import type_api
 
-from .datetime_types import YqlDateTime, YqlTimestamp  # noqa: F401
+from .datetime_types import YqlTimestamp, YqlDateTime  # noqa: F401
 from .json import YqlJSON  # noqa: F401
 
 

--- a/ydb_sqlalchemy/sqlalchemy/types.py
+++ b/ydb_sqlalchemy/sqlalchemy/types.py
@@ -3,7 +3,7 @@ from typing import Any, Mapping, Type, Union
 from sqlalchemy import ARRAY, ColumnElement, exc, types
 from sqlalchemy.sql import type_api
 
-from .datetime_types import YqlDateTime  # noqa: F401
+from .datetime_types import YqlDateTime, YqlTimestamp  # noqa: F401
 from .json import YqlJSON  # noqa: F401
 
 


### PR DESCRIPTION
## Problem
Now the "sa.DateTime", "sa.DATETIME" and "sa.Timestamp" are implemented by "Timestamp" ydb type, which is ok until you need to store data with "seconds" precision (timestamp has microseconds precision).

## Proposal
Let's continue to use "Timestamp" for "sa.DateTime" and "sa.Timestamp", but for "sa.DATETIME" use "DateTime" to allow user to use "DateTime" columns.