### PR TITLE
Add support of DROP INDEX statement

### DIFF
--- a/test/test_core.py
+++ b/test/test_core.py
@@ -1100,6 +1100,25 @@ class TestSecondaryIndex(TestBase):
         cursor = connection.execute(select_stmt)
         assert cursor.one() == ("Sarah Connor", "wanted")
 
+    def test_index_deletion(self, connection: sa.Connection, metadata: sa.MetaData):
+        persons = Table(
+            "test_index_deletion/persons",
+            metadata,
+            sa.Column("id", sa.Integer(), primary_key=True),
+            sa.Column("tax_number", sa.Integer()),
+            sa.Column("full_name", sa.Unicode()),
+        )
+        persons.create(connection)
+        index = sa.Index("ix_tax_number", "tax_number", _table=persons)
+        index.create(connection)
+        indexes = sa.inspect(connection).get_indexes(persons.name)
+        assert len(indexes) == 1
+
+        index.drop(connection)
+
+        indexes = sa.inspect(connection).get_indexes(persons.name)
+        assert len(indexes) == 0
+
 
 class TestTablePathPrefix(TablesTest):
     __backend__ = True

--- a/ydb_sqlalchemy/sqlalchemy/__init__.py
+++ b/ydb_sqlalchemy/sqlalchemy/__init__.py
@@ -13,7 +13,7 @@ from sqlalchemy import util
 from sqlalchemy.engine import characteristics, reflection
 from sqlalchemy.engine.default import DefaultExecutionContext, StrCompileDialect
 from sqlalchemy.exc import CompileError, NoSuchTableError
-from sqlalchemy.sql import functions, literal_column
+from sqlalchemy.sql import ddl, functions, literal_column
 from sqlalchemy.sql.compiler import (
     DDLCompiler,
     IdentifierPreparer,
@@ -462,7 +462,7 @@ class YqlCompiler(StrSQLCompiler):
 
 
 class YqlDDLCompiler(DDLCompiler):
-    def visit_create_index(self, create, include_schema=False, include_table_schema=True, **kw) -> str:
+    def visit_create_index(self, create: ddl.CreateIndex, **kw) -> str:
         index: sa.Index = create.element
         ydb_opts = index.dialect_options.get("ydb", {})
 
@@ -491,7 +491,7 @@ class YqlDDLCompiler(DDLCompiler):
 
         return text
 
-    def visit_drop_index(self, drop, include_schema=False, include_table_schema=True, **kw) -> str:
+    def visit_drop_index(self, drop: ddl.DropIndex, **kw) -> str:
         index: sa.Index = drop.element
 
         self._verify_index_table(index)


### PR DESCRIPTION
## Problem
Now it is impossible to drop existed index:
```python
index.drop(connection)
```
leads to exception:
```
Unexpected token \'DROP\' : cannot match to any predicted input...\n
SQL: 
DROP INDEX <index_name>
```

## Proposed solution
Added an implementation of DROP INDEX to the dialect, so now it render query as:
```
ALTER TABLE <table> DROP INDEX <index>;
```
which is a YQL correct statement.