### PR TITLE
Add request settings to execution options

### DIFF
--- a/ydb_sqlalchemy/dbapi/connection.py
+++ b/ydb_sqlalchemy/dbapi/connection.py
@@ -58,10 +58,17 @@ class Connection:
         self.tx_mode: ydb.AbstractTransactionModeBuilder = ydb.SerializableReadWrite()
         self.tx_context: Optional[ydb.TxContext] = None
         self.use_scan_query: bool = False
+        self.request_settings: ydb.BaseRequestSettings = ydb.BaseRequestSettings()
 
     def cursor(self):
         return self._cursor_class(
-            self.driver, self.session_pool, self.tx_mode, self.tx_context, self.use_scan_query, self.table_path_prefix
+            driver=self.driver,
+            session_pool=self.session_pool,
+            tx_mode=self.tx_mode,
+            tx_context=self.tx_context,
+            request_settings=self.request_settings,
+            use_scan_query=self.use_scan_query,
+            table_path_prefix=self.table_path_prefix,
         )
 
     def describe(self, table_path: str) -> ydb.TableDescription:
@@ -69,7 +76,7 @@ class Connection:
         cursor = self.cursor()
         return cursor.describe_table(abs_table_path)
 
-    def check_exists(self, table_path: str) -> ydb.SchemeEntry:
+    def check_exists(self, table_path: str) -> bool:
         abs_table_path = posixpath.join(self.database, self.table_path_prefix, table_path)
         cursor = self.cursor()
         return cursor.check_exists(abs_table_path)
@@ -123,6 +130,12 @@ class Connection:
 
     def get_ydb_scan_query(self) -> bool:
         return self.use_scan_query
+
+    def set_ydb_request_settings(self, value: ydb.BaseRequestSettings) -> None:
+        self.request_settings = value
+
+    def get_ydb_request_settings(self) -> ydb.BaseRequestSettings:
+        return self.request_settings
 
     def begin(self):
         self.tx_context = None

--- a/ydb_sqlalchemy/dbapi/tracing.py
+++ b/ydb_sqlalchemy/dbapi/tracing.py
@@ -1,0 +1,16 @@
+import importlib.util
+from typing import Optional
+
+
+def maybe_get_current_trace_id() -> Optional[str]:
+    # Check if OpenTelemetry is available
+    if importlib.util.find_spec("opentelemetry"):
+        from opentelemetry import trace
+
+        current_span = trace.get_current_span()
+
+        if current_span.get_span_context().is_valid:
+            return format(current_span.get_span_context().trace_id, "032x")
+
+    # Return None if OpenTelemetry is not available or trace ID is invalid
+    return None

--- a/ydb_sqlalchemy/sqlalchemy/__init__.py
+++ b/ydb_sqlalchemy/sqlalchemy/__init__.py
@@ -585,8 +585,21 @@ class YdbScanQueryCharacteristic(characteristics.ConnectionCharacteristic):
     def set_characteristic(self, dialect: "YqlDialect", dbapi_connection: dbapi.Connection, value: bool) -> None:
         dialect.set_ydb_scan_query(dbapi_connection, value)
 
-    def get_characteristic(self, dialect: "YqlDialect", dbapi_connection: dbapi.Connection) -> Any:
-        dialect.get_ydb_scan_query(dbapi_connection)
+    def get_characteristic(self, dialect: "YqlDialect", dbapi_connection: dbapi.Connection) -> bool:
+        return dialect.get_ydb_scan_query(dbapi_connection)
+
+
+class YdbRequestSettingsCharacteristic(characteristics.ConnectionCharacteristic):
+    def reset_characteristic(self, dialect: "YqlDialect", dbapi_connection: dbapi.Connection) -> None:
+        dialect.reset_ydb_request_settings(dbapi_connection)
+
+    def set_characteristic(
+        self, dialect: "YqlDialect", dbapi_connection: dbapi.Connection, value: ydb.BaseRequestSettings
+    ) -> None:
+        dialect.set_ydb_request_settings(dbapi_connection, value)
+
+    def get_characteristic(self, dialect: "YqlDialect", dbapi_connection: dbapi.Connection) -> ydb.BaseRequestSettings:
+        return dialect.get_ydb_request_settings(dbapi_connection)
 
 
 class YqlDialect(StrCompileDialect):
@@ -638,6 +651,7 @@ class YqlDialect(StrCompileDialect):
         {
             "isolation_level": characteristics.IsolationLevelCharacteristic(),
             "ydb_scan_query": YdbScanQueryCharacteristic(),
+            "ydb_request_settings": YdbRequestSettingsCharacteristic(),
         }
     )
 
@@ -770,8 +784,21 @@ class YqlDialect(StrCompileDialect):
     def reset_ydb_scan_query(self, dbapi_connection: dbapi.Connection):
         self.set_ydb_scan_query(dbapi_connection, False)
 
-    def get_ydb_scan_query(self, dbapi_connection: dbapi.Connection) -> str:
+    def get_ydb_scan_query(self, dbapi_connection: dbapi.Connection) -> bool:
         return dbapi_connection.get_ydb_scan_query()
+
+    def set_ydb_request_settings(
+        self,
+        dbapi_connection: dbapi.Connection,
+        value: ydb.BaseRequestSettings,
+    ) -> None:
+        dbapi_connection.set_ydb_request_settings(value)
+
+    def reset_ydb_request_settings(self, dbapi_connection: dbapi.Connection):
+        self.set_ydb_request_settings(dbapi_connection, ydb.BaseRequestSettings())
+
+    def get_ydb_request_settings(self, dbapi_connection: dbapi.Connection) -> ydb.BaseRequestSettings:
+        return dbapi_connection.get_ydb_request_settings()
 
     def connect(self, *cargs, **cparams):
         return self.loaded_dbapi.connect(*cargs, **cparams)

--- a/ydb_sqlalchemy/sqlalchemy/types.py
+++ b/ydb_sqlalchemy/sqlalchemy/types.py
@@ -3,7 +3,7 @@ from typing import Any, Mapping, Type, Union
 from sqlalchemy import ARRAY, ColumnElement, exc, types
 from sqlalchemy.sql import type_api
 
-from .datetime_types import YqlTimestamp, YqlDateTime  # noqa: F401
+from .datetime_types import YqlDateTime, YqlTimestamp  # noqa: F401
 from .json import YqlJSON  # noqa: F401
 
 


### PR DESCRIPTION
# Problem
Now it is impossible to configure the execution of requests, especially timeout.

# Proposal
Add a connection option `ydb_request_timeout` execution option, which provided to the settings of each execution. Also the trace_id propagation is added.