### PR TITLE
Add TupleType mapping support for YDB

### DIFF
--- a/test/test_suite.py
+++ b/test/test_suite.py
@@ -577,6 +577,19 @@ class ContainerTypesTest(fixtures.TablesTest):
 
         eq_(connection.execute(sa.select(table)).fetchall(), [(1,), (2,), (3,)])
 
+    def test_tuple_list_type_bind_variable_text(self, connection):
+        table = self.tables.container_types_test
+
+        connection.execute(sa.insert(table).values([{"id": 1}, {"id": 2}, {"id": 3}]))
+
+        stmt = select(table.c.id).where(
+            sa.text("(id, id) IN :tuple_arr_var").bindparams(
+                sa.bindparam("tuple_arr_var", type_=sa.ARRAY(sa.TupleType(sa.Integer, sa.Integer))),
+            )
+        )
+
+        eq_(connection.execute(stmt, {"tuple_arr_var": [(1, 1), (2, 2)]}).fetchall(), [(1,), (2,)])
+
 
 class ConcatTest(fixtures.TablesTest):
     @classmethod

--- a/ydb_sqlalchemy/sqlalchemy/compiler/base.py
+++ b/ydb_sqlalchemy/sqlalchemy/compiler/base.py
@@ -228,6 +228,10 @@ class BaseYqlTypeCompiler(StrSQLTypeCompiler):
             ydb_type = ydb.DecimalType(precision, scale)
         elif isinstance(type_, (types.ListType, sa.ARRAY)):
             ydb_type = ydb.ListType(self.get_ydb_type(type_.item_type, is_optional=False))
+        elif isinstance(type_, sa.TupleType):
+            ydb_type = ydb.TupleType()
+            for item_type in type_.types:
+                ydb_type.add_element(self.get_ydb_type(item_type, is_optional=False))
         elif isinstance(type_, types.StructType):
             ydb_type = ydb.StructType()
             for field, field_type in type_.fields_types.items():


### PR DESCRIPTION
- Map SQLAlchemy TupleType to ydb.TupleType in ydb_sqlalchemy/sqlalchemy/compiler/base.py so tuple elements get proper YDB types.
  - Add regression test ContainerTypesTest.test_tuple_list_type_bind_variable_text in test/test_suite.py covering tuple-array bind params in text expressions.