### PR TITLE
Add Alembic integration tests and ship the YDB Alembic impl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,5 @@ dmypy.json
 
 docs/.build/
 .DS_Store
+# staging directory created by alembic.testing.suite
+scratch/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Working in this repository
+
+## CHANGELOG
+
+`CHANGELOG.md` has no "unreleased" section. The pending release notes are simply the bullets above the first `## ` line; that first `## ` line is the latest *released* version.
+
+- Add a single `*` bullet to the very top of `CHANGELOG.md` **only** when a change is meaningful to the end user — new or changed behavior, a bug fix, a performance or compatibility improvement.
+- Do **not** add entries for internal-only work such as tests, coverage, CI, refactors, or documentation.
+- **Never add a heading of any kind.** Not `## Unreleased`, not `## [Unreleased]`, not `## Next`, not a date, not `## X.Y.Z ##`, and no `### Added` / `### Fixed` subsections. Release automation (`.github/scripts/increment_version.py`) inserts the version header above the pending bullets at release time.
+- Do not restyle the file to Keep a Changelog format, and do not reorder or reword existing entries.
+
+This is not a style preference — a heading at the top **breaks the release**. `.github/workflows/python-publish.yml` reads the release notes as everything above the first `## ` line (`sed -e '/^## .*$/,$d'`), so a leading heading makes them empty and the publish job fails with `CHANGELOG empty`. `add_changelog_version` in `increment_version.py` then also skips inserting the real version header, because it returns early when the file already starts with `##`.
+
+Correct — bullets first, no heading of your own:
+
+```md
+* Support YDB view reflection
+* Fix dialect import failure on SQLAlchemy 1.4
+
+## 0.1.22 ##
+* Ignore table schema in reflection and SQL compilation
+```
+
+Wrong:
+
+```md
+## Unreleased
+
+### Added
+* Support YDB view reflection
+
+## 0.1.22 ##
+```
+
+## Tests
+
+`tox -e test-unit` runs the unit tests; `tox -e test-dialect` brings up YDB in Docker and runs the dialect, Alembic and compliance suites against it. `tox -e style` and `tox -e black` are what CI checks for formatting.
+
+Integration tests share one database, so give any table a name unique to the test that creates it rather than assuming an empty schema.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased ##
+* Ship the Alembic integration as `ydb_sqlalchemy.alembic`, so `env.py` no longer has to
+  define its own `DefaultImpl` subclass or override the private `MigrationContext._version`
+* Fix `AttributeError` when binding parameters for a statement built on `sa.table()`/`sa.column()`,
+  which broke `alembic.op.bulk_insert()`
+* Cover Alembic with integration tests: version table, upgrade/downgrade, operations,
+  autogenerate diffs and the unsupported-operation limits
+
 ## 0.1.22 ##
 * Ignore table schema in reflection and SQL compilation
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
   which broke `alembic.op.bulk_insert()`
 * Cover Alembic with integration tests: version table, upgrade/downgrade, operations,
   autogenerate diffs and the unsupported-operation limits
+* Run Alembic's third-party dialect suite (`alembic.testing.suite`) against YDB
 
 ## 0.1.22 ##
 * Ignore table schema in reflection and SQL compilation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
-## Unreleased ##
-* Ship the Alembic integration as `ydb_sqlalchemy.alembic`, so `env.py` no longer has to
-  define its own `DefaultImpl` subclass or override the private `MigrationContext._version`
-* Fix `AttributeError` when binding parameters for a statement built on `sa.table()`/`sa.column()`,
-  which broke `alembic.op.bulk_insert()`
-* Cover Alembic with integration tests: version table, upgrade/downgrade, operations,
-  autogenerate diffs and the unsupported-operation limits
-* Run Alembic's third-party dialect suite (`alembic.testing.suite`) against YDB
+* Ship the Alembic integration as `ydb_sqlalchemy.alembic`, so `env.py` no longer defines its own `DefaultImpl`
+* Fix parameter binding for statements built on `sa.table()`/`sa.column()`, which broke `alembic.op.bulk_insert()`
 
 ## 0.1.22 ##
 * Ignore table schema in reflection and SQL compilation

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -21,6 +21,10 @@ Everything marked *supported* below is covered by an integration test in
 *not supported* is likewise asserted by a test, so if a future YDB release
 lifts a restriction the test starts failing and this table gets updated.
 
+Alembic's own suite for third-party dialects, ``alembic.testing.suite``, runs
+alongside it from ``test/test_alembic_suite.py``, with the YDB feature flags in
+``test/alembic_requirements.py``.
+
 Commands
 ~~~~~~~~
 

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -49,7 +49,8 @@ Commands
      -
    * - ``revision --autogenerate``
      - Supported
-     - See the operations table for what the generated script may contain
+     - Scope it with ``include_name``; see the operations table for what the
+       generated script may contain
    * - ``upgrade --sql`` (offline mode)
      - **Not supported**
      - Schema statements render, version bookkeeping does not
@@ -395,8 +396,6 @@ Creating Indexes
 
 Adding a New Table
 ~~~~~~~~~~~~~~~~~~
-
-.. code-block:: python
 
 YDB has no foreign keys, so a revision can only declare the column and, if the
 lookup needs it, a secondary index:

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -81,7 +81,7 @@ Operations inside a revision
      -
    * - ``create_index`` / ``drop_index``
      - Supported
-     - ``unique=True`` works on non-key columns
+     - But see the note on ``unique`` below
    * - ``bulk_insert``
      - Supported
      -
@@ -119,6 +119,12 @@ outside your model.
 Other limits
 ~~~~~~~~~~~~
 
+- **Unique indexes are not actually unique.** ``create_index(unique=True)``
+  compiles without ``UNIQUE``, so the resulting index does not enforce
+  uniqueness, and reflection reports ``unique: False`` even for an index that
+  is unique. YDB supports unique indexes; this is a gap in the dialect, and
+  autogenerate cannot converge on a model that declares one. Do not rely on
+  ``unique=True`` in a migration until the dialect emits and reflects it.
 - **Branched history is not supported.** The version table can only hold one
   row, so a second head fails with a constraint violation. Keep the history
   linear.

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -51,8 +51,8 @@ Commands
      - Supported
      - See the operations table for what the generated script may contain
    * - ``upgrade --sql`` (offline mode)
-     - Not covered
-     - Untested; no claim is made either way
+     - **Not supported**
+     - Schema statements render, version bookkeeping does not
 
 Operations inside a revision
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -125,6 +125,11 @@ Other limits
   is unique. YDB supports unique indexes; this is a gap in the dialect, and
   autogenerate cannot converge on a model that declares one. Do not rely on
   ``unique=True`` in a migration until the dialect emits and reflects it.
+- **Offline mode does not produce runnable YQL.** ``upgrade --sql`` renders
+  the schema statements correctly, but the ``alembic_version`` insert comes out
+  with an unfilled placeholder for the surrogate key column, and the update
+  that advances a revision would target a primary key column if that column
+  were dropped. Apply migrations online.
 - **Branched history is not supported.** The version table can only hold one
   row, so a second head fails with a constraint violation. Keep the history
   linear.

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -13,7 +13,108 @@ Alembic is SQLAlchemy's database migration tool that allows you to:
 - Rollback to previous schema versions
 - Generate migration scripts automatically
 
-YDB SQLAlchemy provides full Alembic integration with some YDB-specific considerations.
+Support Status
+--------------
+
+Everything marked *supported* below is covered by an integration test in
+``test/test_alembic.py`` and runs on every commit. Everything marked
+*not supported* is likewise asserted by a test, so if a future YDB release
+lifts a restriction the test starts failing and this table gets updated.
+
+Commands
+~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Command
+     - Status
+     - Notes
+   * - ``upgrade`` (``head``, a revision, ``+1``)
+     - Supported
+     - Re-running at head is a no-op
+   * - ``downgrade`` (``-1``, a revision, ``base``)
+     - Supported
+     -
+   * - ``stamp``
+     - Supported
+     - Records the revision without running it
+   * - ``current``, ``history``
+     - Supported
+     -
+   * - ``revision --autogenerate``
+     - Supported
+     - See the operations table for what the generated script may contain
+   * - ``upgrade --sql`` (offline mode)
+     - Not covered
+     - Untested; no claim is made either way
+
+Operations inside a revision
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 20 50
+
+   * - Operation
+     - Status
+     - Notes
+   * - ``create_table``
+     - Supported
+     - Needs a primary key; no foreign keys
+   * - ``drop_table``
+     - Supported
+     -
+   * - ``rename_table``
+     - Supported
+     -
+   * - ``add_column``
+     - Supported
+     - The new column is always nullable
+   * - ``drop_column``
+     - Supported
+     -
+   * - ``create_index`` / ``drop_index``
+     - Supported
+     - ``unique=True`` works on non-key columns
+   * - ``bulk_insert``
+     - Supported
+     -
+   * - ``execute``
+     - Supported
+     - Used for data migrations
+   * - ``alter_column``
+     - **Not supported**
+     - YDB has no ``ALTER COLUMN``, in any form
+   * - Foreign key constraints
+     - **Not supported**
+     - YDB has no foreign keys
+   * - Changing a primary key
+     - **Not supported**
+     - Create a new table, copy, drop, rename
+
+Autogenerate
+~~~~~~~~~~~~
+
+Detects added and removed tables, added and removed columns, and added
+indexes, and produces an empty diff when the model matches the database.
+Because it cannot emit ``alter_column``, a changed column type or nullability
+has to be resolved by hand.
+
+Autogenerate compares against every table in the database, so scope it with
+``include_name``/``include_object`` in ``env.py`` if the database holds tables
+outside your model.
+
+Other limits
+~~~~~~~~~~~~
+
+- **Branched history is not supported.** The version table can only hold one
+  row, so a second head fails with a constraint violation. Keep the history
+  linear.
+- **Migrations are not atomic.** YDB cannot run schema operations in a
+  transaction, so a revision that fails part way through leaves the schema
+  partly migrated. Keep revisions small.
 
 Installation
 ------------
@@ -276,6 +377,11 @@ Adding a New Table
 
 .. code-block:: python
 
+YDB has no foreign keys, so a revision can only declare the column and, if the
+lookup needs it, a secondary index:
+
+.. code-block:: python
+
    def upgrade() -> None:
        op.create_table('posts',
            sa.Column('id', UInt64(), nullable=False),
@@ -284,8 +390,8 @@ Adding a New Table
            sa.Column('content', sa.Text(), nullable=True),
            sa.Column('created_at', sa.DateTime(), nullable=False),
            sa.PrimaryKeyConstraint('id'),
-           sa.ForeignKeyConstraint(['user_id'], ['users.id'])
        )
+       op.create_index('ix_posts_user_id', 'posts', ['user_id'])
 
    def downgrade() -> None:
        op.drop_table('posts')

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -87,16 +87,20 @@ This creates an ``alembic.ini`` configuration file and a ``migrations/`` directo
 YDB-Specific Configuration
 --------------------------
 
-YDB requires special configuration in ``env.py`` due to its unique characteristics:
+Alembic dispatches on the SQLAlchemy dialect name and refuses to start unless an
+implementation is registered for that name, so ``env.py`` has to import the one
+shipped with this package. The import is the whole integration: ``YDBImpl``
+registers itself for the ``yql`` dialect, and it gives the ``alembic_version``
+table a layout YDB accepts.
 
 .. code-block:: python
 
    # migrations/env.py
    from logging.config import fileConfig
-   import sqlalchemy as sa
    from sqlalchemy import engine_from_config, pool
    from alembic import context
-   from alembic.ddl.impl import DefaultImpl
+
+   from ydb_sqlalchemy.alembic import YDBImpl  # noqa: F401
 
    # Import your models
    from myapp.models import Base
@@ -107,10 +111,6 @@ YDB requires special configuration in ``env.py`` due to its unique characteristi
        fileConfig(config.config_file_name)
 
    target_metadata = Base.metadata
-
-   # YDB-specific implementation
-   class YDBImpl(DefaultImpl):
-       __dialect__ = "yql"
 
    def run_migrations_offline() -> None:
        """Run migrations in 'offline' mode."""
@@ -139,15 +139,6 @@ YDB requires special configuration in ``env.py`` due to its unique characteristi
                target_metadata=target_metadata
            )
 
-           # YDB-specific: Custom version table structure
-           ctx = context.get_context()
-           ctx._version = sa.Table(
-               ctx.version_table,
-               sa.MetaData(),
-               sa.Column("version_num", sa.String(32), nullable=False),
-               sa.Column("id", sa.Integer(), nullable=True, primary_key=True),
-           )
-
            with context.begin_transaction():
                context.run_migrations()
 
@@ -155,6 +146,20 @@ YDB requires special configuration in ``env.py`` due to its unique characteristi
        run_migrations_offline()
    else:
        run_migrations_online()
+
+The Version Table
+~~~~~~~~~~~~~~~~~
+
+``YDBImpl`` creates ``alembic_version`` with an extra, always-``NULL`` ``id``
+column that serves as its primary key, instead of Alembic's usual primary key on
+``version_num``. Two YDB rules force this: a primary key column cannot be
+updated, and Alembic advances a revision with
+``UPDATE alembic_version SET version_num = ...``; and the named primary key
+constraint Alembic emits by default is rejected by the YDB parser.
+
+A consequence is that branched migrations are not supported -- more than one
+head would need more than one row, and the rows would collide on a ``NULL``
+primary key. Keep the revision history linear.
 
 Creating Your First Migration
 -----------------------------
@@ -239,20 +244,21 @@ Adding a Column
 Modifying a Column
 ~~~~~~~~~~~~~~~~~~
 
+``op.alter_column()`` is not usable on YDB -- see `Column Alteration Is Not
+Supported`_. Replace a column by adding the replacement, copying the data and
+dropping the original:
+
 .. code-block:: python
 
-   # Change column type (be careful with YDB limitations)
    def upgrade() -> None:
-       op.alter_column('users', 'username',
-                      existing_type=sa.String(50),
-                      type_=sa.String(100),
-                      nullable=False)
+       op.add_column('users', sa.Column('username_v2', sa.Unicode(100)))
+       op.execute('UPDATE `users` SET username_v2 = username')
+       op.drop_column('users', 'username')
 
    def downgrade() -> None:
-       op.alter_column('users', 'username',
-                      existing_type=sa.String(100),
-                      type_=sa.String(50),
-                      nullable=False)
+       op.add_column('users', sa.Column('username', sa.Unicode(50)))
+       op.execute('UPDATE `users` SET username = username_v2')
+       op.drop_column('users', 'username_v2')
 
 Creating Indexes
 ~~~~~~~~~~~~~~~~
@@ -305,22 +311,37 @@ YDB doesn't support modifying primary key columns. Plan your primary keys carefu
    # 3. Drop old table
    # 4. Rename new table
 
-Data Type Constraints
-~~~~~~~~~~~~~~~~~~~~~
+.. _Column Alteration Is Not Supported:
 
-Some type changes are not supported:
+Column Alteration Is Not Supported
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+YDB has no ``ALTER TABLE ... ALTER COLUMN``, so ``op.alter_column()`` fails for
+every kind of change -- including widening a string, which other databases
+accept:
 
 .. code-block:: python
 
-   # Supported: Increasing string length
+   # All of these raise: no viable alternative at input 'ALTER COLUMN'
    op.alter_column('users', 'username',
-                  existing_type=sa.String(50),
-                  type_=sa.String(100))
+                  existing_type=sa.Unicode(50),
+                  type_=sa.Unicode(100))
 
-   # Not supported: Changing fundamental type
-   # op.alter_column('users', 'id',
-   #                existing_type=UInt32(),
-   #                type_=UInt64())  # This won't work
+   op.alter_column('users', 'id',
+                  existing_type=UInt32(),
+                  type_=UInt64())
+
+Making an existing column non-nullable is rejected separately, with
+``SET NOT NULL is currently not supported``:
+
+.. code-block:: python
+
+   op.alter_column('users', 'status', nullable=False)  # Fails
+
+Add-copy-drop, as shown in `Modifying a Column`_, is the way to change a
+column. For a primary key column even that is not enough, because the primary
+key of an existing table cannot be changed at all; create a new table, copy the
+data into it, drop the old one and rename.
 
 Working with YDB Types
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -371,8 +392,9 @@ Sometimes you need to migrate data along with schema:
            users_table.update().values(status='active')
        )
 
-       # Make column non-nullable
-       op.alter_column('users', 'status', nullable=False)
+       # The column stays nullable: YDB cannot add NOT NULL to an existing
+       # column. Declare it NOT NULL at CREATE TABLE time, or enforce it in
+       # the application.
 
    def downgrade() -> None:
        op.drop_column('users', 'status')
@@ -397,21 +419,23 @@ Migration Best Practices
 1. **Test Migrations**: Always test migrations on a copy of production data
 2. **Backup Data**: Backup your data before running migrations in production
 3. **Review Generated Migrations**: Always review auto-generated migrations before applying
-4. **Use Transactions**: Migrations run in transactions by default
-5. **Plan Primary Keys**: Design primary keys carefully as they can't be easily changed
+4. **Do Not Rely on Atomicity**: YDB cannot run schema operations inside a
+   transaction, so a revision that fails part way through leaves the schema
+   partly migrated. Keep revisions small so that re-running one after a manual
+   fix is cheap.
+5. **Plan Primary Keys**: Design primary keys carefully as they can't be changed
+6. **Plan Nullability**: A column can only be made ``NOT NULL`` when the table is
+   created
 
 .. code-block:: python
 
    # Good migration practices
    def upgrade() -> None:
-       # Add columns as nullable first
+       # One schema change per revision, so a failure is easy to place
        op.add_column('users', sa.Column('new_field', sa.String(100), nullable=True))
 
        # Populate data
        # ... data migration code ...
-
-       # Then make non-nullable if needed
-       op.alter_column('users', 'new_field', nullable=False)
 
 Common Commands
 ---------------

--- a/docs/migrations.rst
+++ b/docs/migrations.rst
@@ -83,10 +83,16 @@ Operations inside a revision
      -
    * - ``execute``
      - Supported
-     - Used for data migrations
-   * - ``alter_column``
+     - Raw DDL must be wrapped in ``sa.schema.DDL``
+   * - ``alter_column`` (``nullable=True``)
+     - Supported
+     - Maps onto YDB's ``DROP NOT NULL``
+   * - ``alter_column`` (``nullable=False``)
      - **Not supported**
-     - YDB has no ``ALTER COLUMN``, in any form
+     - YDB: ``SET NOT NULL is currently not supported``
+   * - ``alter_column`` (``type_=``)
+     - **Not supported**
+     - YDB's ``ALTER COLUMN`` changes options, not types
    * - Foreign key constraints
      - **Not supported**
      - YDB has no foreign keys
@@ -99,8 +105,8 @@ Autogenerate
 
 Detects added and removed tables, added and removed columns, and added
 indexes, and produces an empty diff when the model matches the database.
-Because it cannot emit ``alter_column``, a changed column type or nullability
-has to be resolved by hand.
+A changed column type has to be resolved by hand, since the ``alter_column``
+autogenerate would emit for it is not executable on YDB.
 
 Autogenerate compares against every table in the database, so scope it with
 ``include_name``/``include_object`` in ``env.py`` if the database holds tables
@@ -345,9 +351,9 @@ Adding a Column
 Modifying a Column
 ~~~~~~~~~~~~~~~~~~
 
-``op.alter_column()`` is not usable on YDB -- see `Column Alteration Is Not
-Supported`_. Replace a column by adding the replacement, copying the data and
-dropping the original:
+``op.alter_column()`` on YDB can only relax nullability, not change a type --
+see `What alter_column Can Change`_. Replace a column by adding the
+replacement, copying the data and dropping the original:
 
 .. code-block:: python
 
@@ -417,37 +423,61 @@ YDB doesn't support modifying primary key columns. Plan your primary keys carefu
    # 3. Drop old table
    # 4. Rename new table
 
-.. _Column Alteration Is Not Supported:
+.. _What alter_column Can Change:
 
-Column Alteration Is Not Supported
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+What ``alter_column`` Can Change
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-YDB has no ``ALTER TABLE ... ALTER COLUMN``, so ``op.alter_column()`` fails for
-every kind of change -- including widening a string, which other databases
-accept:
+YDB's `ALTER COLUMN <https://ydb.tech/docs/en/yql/reference/syntax/alter_table/columns>`_
+changes column *options* -- it can drop ``NOT NULL`` and set ``FAMILY``,
+``DEFAULT`` or ``COMPRESSION``. It cannot change a column's type. Of the
+changes Alembic can express, only relaxing nullability goes through.
+
+Relaxing ``NOT NULL`` works, because it maps onto ``DROP NOT NULL``:
 
 .. code-block:: python
 
-   # All of these raise: no viable alternative at input 'ALTER COLUMN'
    op.alter_column('users', 'username',
                   existing_type=sa.Unicode(50),
-                  type_=sa.Unicode(100))
+                  nullable=True)  # Works
 
-   op.alter_column('users', 'id',
-                  existing_type=UInt32(),
-                  type_=UInt64())
-
-Making an existing column non-nullable is rejected separately, with
+Adding ``NOT NULL`` does not; YDB answers
 ``SET NOT NULL is currently not supported``:
 
 .. code-block:: python
 
    op.alter_column('users', 'status', nullable=False)  # Fails
 
-Add-copy-drop, as shown in `Modifying a Column`_, is the way to change a
-column. For a primary key column even that is not enough, because the primary
-key of an existing table cannot be changed at all; create a new table, copy the
-data into it, drop the old one and rename.
+Changing a type does not either. Alembic emits ``ALTER COLUMN ... TYPE ...``,
+which the YQL parser rejects with
+``no viable alternative at input 'ALTER COLUMN'`` -- including for a widening
+change that other databases accept:
+
+.. code-block:: python
+
+   op.alter_column('users', 'username',
+                  existing_type=sa.Unicode(50),
+                  type_=sa.Unicode(100))  # Fails
+
+Use add-copy-drop, as shown in `Modifying a Column`_, to change a type. For a
+primary key column even that is not enough, because the primary key of an
+existing table cannot be changed; create a new table, copy the data into it,
+drop the old one and rename.
+
+The remaining ``ALTER COLUMN`` options have no Alembic operation, so reach them
+with raw YQL. Wrap the statement in ``sa.schema.DDL``: the dialect only sends a
+statement to the YDB scheme service when SQLAlchemy marks it as DDL, and a
+plain string is not marked, so it reaches the query service and is rejected
+with ``Scheme operations cannot be executed inside transaction``.
+
+.. code-block:: python
+
+   op.execute(sa.schema.DDL(
+       'ALTER TABLE `users` ALTER COLUMN `username` SET FAMILY default'
+   ))
+
+This applies to any raw DDL passed to ``op.execute``. Raw DML -- an ``UPDATE``
+in a data migration, say -- is fine as a plain string.
 
 Working with YDB Types
 ~~~~~~~~~~~~~~~~~~~~~~

--- a/examples/alembic/README.md
+++ b/examples/alembic/README.md
@@ -20,50 +20,25 @@ pip install alembic
 
 ## Preparation
 
-We have to setup `alembic` correctly.
-First of all, we should register `YDB` dialect in `env.py`:
+`alembic` dispatches on the SQLAlchemy dialect name and refuses to start unless an
+implementation is registered for it, so `env.py` has to import the one shipped with
+`ydb-sqlalchemy`. The import is the whole setup:
 
 ```python3
-from alembic.ddl.impl import DefaultImpl
-
-
-class YDBImpl(DefaultImpl):
-    __dialect__ = "yql"
+from ydb_sqlalchemy.alembic import YDBImpl  # noqa: F401
 ```
 
-Secondly, since `YDB` do not support updating primary key columns, we have to update alembic table structure.
-For this purpose we should update `run_migrations_online` method in `env.py`:
+`YDBImpl` registers itself for the `yql` dialect on import, and it also gives the
+`alembic_version` table a layout `YDB` accepts. `alembic` normally makes
+`version_num` the primary key, which does not work here for two reasons: `YDB`
+cannot update a primary key column, and `alembic` advances a revision with
+`UPDATE alembic_version SET version_num = ...`; and the named primary key
+constraint `alembic` emits by default is rejected by the `YDB` parser. `YDBImpl`
+adds a surrogate primary key column instead, so no changes to
+`run_migrations_online` are needed.
 
-```python3
-def run_migrations_online() -> None:
-    """Run migrations in 'online' mode.
-
-    In this scenario we need to create an Engine
-    and associate a connection with the context.
-
-    """
-    connectable = engine_from_config(
-        config.get_section(config.config_ini_section, {}),
-        prefix="sqlalchemy.",
-        poolclass=pool.NullPool,
-    )
-
-    with connectable.connect() as connection:
-        context.configure(
-            connection=connection, target_metadata=target_metadata
-        )
-
-        ctx = context.get_context()
-        ctx._version = sa.Table(  # noqa: SLF001
-            ctx.version_table,
-            sa.MetaData(),
-            sa.Column("version_num", sa.String(32), nullable=False),
-            sa.Column("id", sa.Integer(), nullable=True, primary_key=True),
-        )
-
-        with context.begin_transaction():
-            context.run_migrations()
-```
+Because the single version row is keyed on an always-`NULL` surrogate column,
+branched migrations are not supported -- keep the revision history linear.
 
 ## Example
 

--- a/examples/alembic/migrations/env.py
+++ b/examples/alembic/migrations/env.py
@@ -1,11 +1,11 @@
 from logging.config import fileConfig
 
-import sqlalchemy as sa
 from sqlalchemy import engine_from_config
 from sqlalchemy import pool
 
 from alembic import context
-from alembic.ddl.impl import DefaultImpl
+
+from ydb_sqlalchemy.alembic import YDBImpl  # noqa: F401
 
 
 # this is the Alembic Config object, which provides
@@ -29,10 +29,6 @@ target_metadata = Base.metadata
 # can be acquired:
 # my_important_option = config.get_main_option("my_important_option")
 # ... etc.
-
-
-class YDBImpl(DefaultImpl):
-    __dialect__ = "yql"
 
 
 def run_migrations_offline() -> None:
@@ -75,14 +71,6 @@ def run_migrations_online() -> None:
     with connectable.connect() as connection:
         context.configure(
             connection=connection, target_metadata=target_metadata
-        )
-
-        ctx = context.get_context()
-        ctx._version = sa.Table(  # noqa: SLF001
-            ctx.version_table,
-            sa.MetaData(),
-            sa.Column("version_num", sa.String(32), nullable=False),
-            sa.Column("id", sa.Integer(), nullable=True, primary_key=True),
         )
 
         with context.begin_transaction():

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,7 +2,7 @@
 addopts= --tb native -v -r fxX -p no:warnings
 
 [sqla_testing]
-requirement_cls=ydb_sqlalchemy.sqlalchemy.requirements:Requirements
+requirement_cls=test.alembic_requirements:Requirements
 profile_file=test/profiles.txt
 
 [db]

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -4,6 +4,8 @@ greenlet
 sqlalchemy==2.0.7
 ydb >= 3.18.8
 ydb-dbapi >= 0.1.1
+# 1.14 added DefaultImpl.version_table_impl, which ydb_sqlalchemy.alembic overrides
+alembic >= 1.14
 requests<2.29
 pytest==7.2.2
 docker==6.0.1

--- a/test/alembic_requirements.py
+++ b/test/alembic_requirements.py
@@ -1,0 +1,84 @@
+"""Requirements for the SQLAlchemy suite plus, when available, Alembic's.
+
+Alembic's third-party dialect suite reads its own feature flags off the same
+requirements object the SQLAlchemy suite uses, so the two sets have to be
+combined into one class. Alembic stays optional: without it installed this is
+the plain dialect requirements class.
+"""
+
+from ydb_sqlalchemy.sqlalchemy.requirements import Requirements as DialectRequirements
+
+try:
+    from alembic.testing.requirements import SuiteRequirements as AlembicRequirements
+except ImportError:  # pragma: no cover
+    AlembicRequirements = object
+
+from sqlalchemy.testing import exclusions
+
+
+class Requirements(DialectRequirements, AlembicRequirements):
+    @property
+    def alter_column(self):
+        # YDB's ALTER COLUMN sets column options and can DROP NOT NULL; it
+        # cannot change a type, which is what the suite alters.
+        return exclusions.closed()
+
+    @property
+    def comments(self):
+        return exclusions.closed()
+
+    @property
+    def computed_columns(self):
+        return exclusions.closed()
+
+    @property
+    def identity_columns(self):
+        return exclusions.closed()
+
+    @property
+    def identity_columns_alter(self):
+        return exclusions.closed()
+
+    @property
+    def autoincrement_on_composite_pk(self):
+        return exclusions.closed()
+
+    @property
+    def fk_names(self):
+        return exclusions.closed()
+
+    @property
+    def fk_initially(self):
+        return exclusions.closed()
+
+    @property
+    def fk_deferrable(self):
+        return exclusions.closed()
+
+    @property
+    def fk_deferrable_is_reflected(self):
+        return exclusions.closed()
+
+    @property
+    def fk_ondelete_is_reflected(self):
+        return exclusions.closed()
+
+    @property
+    def fk_onupdate_is_reflected(self):
+        return exclusions.closed()
+
+    @property
+    def fk_onupdate(self):
+        return exclusions.closed()
+
+    @property
+    def fk_ondelete_restrict(self):
+        return exclusions.closed()
+
+    @property
+    def fk_onupdate_restrict(self):
+        return exclusions.closed()
+
+    @property
+    def fk_ondelete_noaction(self):
+        return exclusions.closed()

--- a/test/test_alembic.py
+++ b/test/test_alembic.py
@@ -1,0 +1,574 @@
+"""Integration tests for running Alembic against YDB.
+
+The suite covers the migration path the documentation promises: the shape of
+the version table, ``upgrade``/``downgrade`` over a revision chain, the
+individual operations available inside a revision, autogenerate diffs, and the
+YDB limitations that migrations have to be written around.
+
+Each test works on tables whose names carry a unique suffix, so the suite is
+safe to run against a shared database and does not depend on it being empty.
+"""
+
+import uuid
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy.testing import config as sa_test_config
+from sqlalchemy.testing.fixtures import TestBase
+
+alembic = pytest.importorskip("alembic", minversion="1.14")
+
+from alembic import command  # noqa: E402
+from alembic.autogenerate import compare_metadata  # noqa: E402
+from alembic.config import Config  # noqa: E402
+from alembic.migration import MigrationContext  # noqa: E402
+from alembic.operations import Operations  # noqa: E402
+
+from ydb_sqlalchemy.alembic import VERSION_TABLE_PK_COLUMN, YDBImpl  # noqa: E402,F401
+from ydb_sqlalchemy.sqlalchemy import types as ydb_types  # noqa: E402
+
+ENV_PY = """
+import sqlalchemy as sa
+from sqlalchemy import pool
+
+from alembic import context
+from ydb_sqlalchemy.alembic import YDBImpl  # noqa: F401
+
+config = context.config
+version_table = config.get_main_option("version_table")
+
+connectable = sa.create_engine(config.get_main_option("sqlalchemy.url"), poolclass=pool.NullPool)
+try:
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=None,
+            version_table=version_table,
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+finally:
+    connectable.dispose()
+"""
+
+SCRIPT_MAKO = '''"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+"""
+import sqlalchemy as sa
+
+from alembic import op
+
+revision = ${repr(up_revision)}
+down_revision = ${repr(down_revision)}
+branch_labels = ${repr(branch_labels)}
+depends_on = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}
+'''
+
+
+def unique_suffix() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+@pytest.fixture(scope="module")
+def sync_url():
+    """URL of the database under test, restricted to the sync driver.
+
+    Alembic's ``command`` API and ``MigrationContext`` are synchronous, so the
+    suite is skipped when the test session runs against ``ydb_async``.
+    """
+    url = sa_test_config.db.url
+    if sa_test_config.db.dialect.is_async:
+        pytest.skip("Alembic's synchronous API cannot drive the async YDB driver")
+    return url
+
+
+@pytest.fixture
+def engine(sync_url):
+    engine = sa.create_engine(sync_url, poolclass=sa.pool.NullPool)
+    yield engine
+    engine.dispose()
+
+
+def drop_tables(engine, *names) -> None:
+    """Drop tables if they exist, one connection per statement.
+
+    The dialect only routes a statement to the YDB scheme service when
+    SQLAlchemy marks it as DDL, and YDB refuses schema operations inside a
+    transaction, so each drop goes through a ``Table.drop`` construct on a
+    freshly committed connection rather than through raw SQL.
+    """
+    with engine.connect() as conn:
+        existing = set(sa.inspect(conn).get_table_names())
+    for name in names:
+        if name not in existing:
+            continue
+        with engine.connect() as conn:
+            sa.Table(name, sa.MetaData()).drop(conn)
+            conn.commit()
+
+
+class AlembicEnv:
+    """A self-contained Alembic project in a temporary directory."""
+
+    def __init__(self, root, url, version_table):
+        self.root = root
+        self.url = url
+        self.version_table = version_table
+        self.versions = root / "migrations" / "versions"
+        self.versions.mkdir(parents=True)
+        (root / "migrations" / "env.py").write_text(ENV_PY)
+        (root / "migrations" / "script.py.mako").write_text(SCRIPT_MAKO)
+        self._revisions = []
+
+    @property
+    def config(self) -> Config:
+        cfg = Config()
+        cfg.set_main_option("script_location", str(self.root / "migrations"))
+        cfg.set_main_option("sqlalchemy.url", str(self.url))
+        cfg.set_main_option("version_table", self.version_table)
+        return cfg
+
+    def add_revision(self, revision: str, upgrade: str, downgrade: str) -> None:
+        """Write a revision file chained onto the previously added one."""
+        down_revision = self._revisions[-1] if self._revisions else None
+        self._revisions.append(revision)
+        body = (
+            "import sqlalchemy as sa\n"
+            "from alembic import op\n"
+            "\n"
+            f"revision = {revision!r}\n"
+            f"down_revision = {down_revision!r}\n"
+            "branch_labels = None\n"
+            "depends_on = None\n"
+            "\n"
+            "def upgrade():\n"
+            f"{upgrade}\n"
+            "\n"
+            "def downgrade():\n"
+            f"{downgrade}\n"
+        )
+        (self.versions / f"{revision}_.py").write_text(body)
+
+    def upgrade(self, revision: str = "head") -> None:
+        command.upgrade(self.config, revision)
+
+    def downgrade(self, revision: str) -> None:
+        command.downgrade(self.config, revision)
+
+    def stamp(self, revision: str) -> None:
+        command.stamp(self.config, revision)
+
+    def current_heads(self, engine):
+        with engine.connect() as conn:
+            ctx = MigrationContext.configure(conn, opts={"version_table": self.version_table})
+            return set(ctx.get_current_heads())
+
+
+@pytest.fixture
+def alembic_env(tmp_path, engine, sync_url):
+    suffix = unique_suffix()
+    env = AlembicEnv(tmp_path, sync_url, version_table=f"alembic_version_{suffix}")
+    env.suffix = suffix
+    env.table = f"orders_{suffix}"
+    yield env
+    drop_tables(engine, env.table, f"{env.table}_renamed", env.version_table)
+
+
+@pytest.fixture
+def migration_ctx(engine):
+    """An ``Operations`` object bound to a live connection.
+
+    Exercises revision bodies without going through revision files.
+    """
+    with engine.connect() as conn:
+        yield Operations(MigrationContext.configure(conn))
+
+
+class TestVersionTable(TestBase):
+    def test_version_table_is_created_and_tracks_head(self, alembic_env, engine):
+        alembic_env.add_revision(
+            "0001",
+            "    op.create_table(%r, sa.Column('id', sa.Integer, primary_key=True))" % alembic_env.table,
+            "    op.drop_table(%r)" % alembic_env.table,
+        )
+        alembic_env.upgrade()
+
+        assert alembic_env.current_heads(engine) == {"0001"}
+
+    def test_version_table_shape_is_accepted_by_ydb(self, alembic_env, engine):
+        """The version table needs a surrogate primary key on YDB.
+
+        ``version_num`` cannot be the primary key because Alembic advances a
+        revision with an ``UPDATE`` of that column and YDB cannot update a
+        primary key column. Alembic's default named primary key constraint is
+        also rejected by the YDB parser.
+        """
+        alembic_env.stamp("head")
+
+        with engine.connect() as conn:
+            inspector = sa.inspect(conn)
+            columns = {c["name"]: c for c in inspector.get_columns(alembic_env.version_table)}
+            pk = inspector.get_pk_constraint(alembic_env.version_table)
+
+        assert set(columns) == {"version_num", VERSION_TABLE_PK_COLUMN}
+        assert columns["version_num"]["nullable"] is False
+        assert pk["constrained_columns"] == [VERSION_TABLE_PK_COLUMN]
+        assert pk["name"] is None, "YDB rejects named primary key constraints"
+
+    def test_stamp_does_not_run_migrations(self, alembic_env, engine):
+        alembic_env.add_revision(
+            "0001",
+            "    op.create_table(%r, sa.Column('id', sa.Integer, primary_key=True))" % alembic_env.table,
+            "    op.drop_table(%r)" % alembic_env.table,
+        )
+        alembic_env.stamp("0001")
+
+        assert alembic_env.current_heads(engine) == {"0001"}
+        with engine.connect() as conn:
+            assert not sa.inspect(conn).has_table(alembic_env.table)
+
+
+class TestUpgradeDowngrade(TestBase):
+    @pytest.fixture
+    def chain(self, alembic_env):
+        table = alembic_env.table
+        alembic_env.add_revision(
+            "0001",
+            "    op.create_table(\n"
+            f"        {table!r},\n"
+            "        sa.Column('id', sa.Integer, primary_key=True),\n"
+            "        sa.Column('name', sa.Unicode),\n"
+            "    )",
+            f"    op.drop_table({table!r})",
+        )
+        alembic_env.add_revision(
+            "0002",
+            f"    op.add_column({table!r}, sa.Column('qty', sa.Integer))",
+            f"    op.drop_column({table!r}, 'qty')",
+        )
+        alembic_env.add_revision(
+            "0003",
+            f"    op.create_index('ix_{alembic_env.suffix}_name', {table!r}, ['name'])",
+            f"    op.drop_index('ix_{alembic_env.suffix}_name', table_name={table!r})",
+        )
+        return alembic_env
+
+    def test_upgrade_head_applies_whole_chain(self, chain, engine):
+        chain.upgrade()
+
+        assert chain.current_heads(engine) == {"0003"}
+        with engine.connect() as conn:
+            inspector = sa.inspect(conn)
+            assert [c["name"] for c in inspector.get_columns(chain.table)] == ["id", "name", "qty"]
+            assert [i["name"] for i in inspector.get_indexes(chain.table)] == [f"ix_{chain.suffix}_name"]
+
+    def test_upgrade_one_revision_at_a_time(self, chain, engine):
+        chain.upgrade("0001")
+        assert chain.current_heads(engine) == {"0001"}
+        with engine.connect() as conn:
+            assert [c["name"] for c in sa.inspect(conn).get_columns(chain.table)] == ["id", "name"]
+
+        chain.upgrade("+1")
+        assert chain.current_heads(engine) == {"0002"}
+        with engine.connect() as conn:
+            assert "qty" in [c["name"] for c in sa.inspect(conn).get_columns(chain.table)]
+
+    def test_downgrade_reverses_each_revision(self, chain, engine):
+        chain.upgrade()
+
+        chain.downgrade("-1")
+        assert chain.current_heads(engine) == {"0002"}
+        with engine.connect() as conn:
+            assert sa.inspect(conn).get_indexes(chain.table) == []
+
+        chain.downgrade("-1")
+        assert chain.current_heads(engine) == {"0001"}
+        with engine.connect() as conn:
+            assert "qty" not in [c["name"] for c in sa.inspect(conn).get_columns(chain.table)]
+
+    def test_downgrade_to_base_removes_table_and_clears_version(self, chain, engine):
+        chain.upgrade()
+        chain.downgrade("base")
+
+        assert chain.current_heads(engine) == set()
+        with engine.connect() as conn:
+            assert not sa.inspect(conn).has_table(chain.table)
+
+    def test_upgrade_is_idempotent_at_head(self, chain, engine):
+        chain.upgrade()
+        chain.upgrade()
+
+        assert chain.current_heads(engine) == {"0003"}
+
+
+class TestOperations(TestBase):
+    """The operations a revision body can use, run against a live connection."""
+
+    @pytest.fixture
+    def table_name(self, engine):
+        name = f"ops_{unique_suffix()}"
+        yield name
+        drop_tables(engine, name, f"{name}_renamed")
+
+    def _create(self, op, name):
+        op.create_table(
+            name,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("name", sa.Unicode),
+        )
+
+    def test_create_and_drop_table(self, migration_ctx, engine, table_name):
+        self._create(migration_ctx, table_name)
+        with engine.connect() as conn:
+            assert sa.inspect(conn).has_table(table_name)
+
+        migration_ctx.drop_table(table_name)
+        with engine.connect() as conn:
+            assert not sa.inspect(conn).has_table(table_name)
+
+    def test_add_and_drop_column(self, migration_ctx, engine, table_name):
+        self._create(migration_ctx, table_name)
+
+        migration_ctx.add_column(table_name, sa.Column("qty", sa.Integer))
+        with engine.connect() as conn:
+            assert "qty" in [c["name"] for c in sa.inspect(conn).get_columns(table_name)]
+
+        migration_ctx.drop_column(table_name, "qty")
+        with engine.connect() as conn:
+            assert "qty" not in [c["name"] for c in sa.inspect(conn).get_columns(table_name)]
+
+    def test_create_and_drop_index(self, migration_ctx, engine, table_name):
+        self._create(migration_ctx, table_name)
+        index_name = f"ix_{table_name}_name"
+
+        migration_ctx.create_index(index_name, table_name, ["name"])
+        with engine.connect() as conn:
+            assert [i["name"] for i in sa.inspect(conn).get_indexes(table_name)] == [index_name]
+
+        migration_ctx.drop_index(index_name, table_name=table_name)
+        with engine.connect() as conn:
+            assert sa.inspect(conn).get_indexes(table_name) == []
+
+    def test_rename_table(self, migration_ctx, engine, table_name):
+        self._create(migration_ctx, table_name)
+
+        migration_ctx.rename_table(table_name, f"{table_name}_renamed")
+        with engine.connect() as conn:
+            inspector = sa.inspect(conn)
+            assert not inspector.has_table(table_name)
+            assert inspector.has_table(f"{table_name}_renamed")
+
+    def test_bulk_insert_with_lightweight_table(self, migration_ctx, engine, table_name):
+        """``sa.table()``/``sa.column()`` is the form Alembic documents here.
+
+        Its columns are ``ColumnClause`` objects without ``nullable`` or
+        ``primary_key``, which used to make bind-type inference raise
+        ``AttributeError`` for the executemany path.
+        """
+        self._create(migration_ctx, table_name)
+        table = sa.table(
+            table_name,
+            sa.column("id", sa.Integer),
+            sa.column("name", sa.Unicode),
+        )
+
+        migration_ctx.bulk_insert(table, [{"id": 1, "name": "a"}, {"id": 2, "name": "b"}])
+
+        with engine.connect() as conn:
+            rows = conn.execute(sa.text(f"SELECT id, name FROM `{table_name}` ORDER BY id")).fetchall()
+        assert rows == [(1, "a"), (2, "b")]
+
+    def test_bulk_insert_with_full_table(self, migration_ctx, engine, table_name):
+        self._create(migration_ctx, table_name)
+        table = sa.Table(
+            table_name,
+            sa.MetaData(),
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("name", sa.Unicode),
+        )
+
+        migration_ctx.bulk_insert(table, [{"id": 1, "name": "a"}, {"id": 2, "name": None}])
+
+        with engine.connect() as conn:
+            rows = conn.execute(sa.text(f"SELECT id, name FROM `{table_name}` ORDER BY id")).fetchall()
+        assert rows == [(1, "a"), (2, None)]
+
+
+class TestUnsupportedOperations(TestBase):
+    """YDB limitations that migrations have to be written around.
+
+    These are asserted rather than merely documented so that a future YDB or
+    dialect release that lifts a limitation shows up as a failing test.
+    """
+
+    @pytest.fixture
+    def table_name(self, engine, migration_ctx):
+        name = f"lim_{unique_suffix()}"
+        migration_ctx.create_table(
+            name,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("label", sa.Unicode(50)),
+            sa.Column("qty", sa.Integer),
+        )
+        yield name
+        drop_tables(engine, name)
+
+    def test_alter_column_type_is_rejected(self, migration_ctx, table_name):
+        """YDB has no ``ALTER COLUMN ... TYPE``, not even to widen a string."""
+        with pytest.raises(sa.exc.DatabaseError, match="ALTER COLUMN"):
+            migration_ctx.alter_column(
+                table_name,
+                "label",
+                existing_type=sa.Unicode(50),
+                type_=sa.Unicode(100),
+            )
+
+    def test_alter_primary_key_column_type_is_rejected(self, migration_ctx, table_name):
+        with pytest.raises(sa.exc.DatabaseError, match="ALTER COLUMN"):
+            migration_ctx.alter_column(
+                table_name,
+                "id",
+                existing_type=sa.Integer(),
+                type_=sa.BigInteger(),
+            )
+
+    def test_setting_column_not_null_is_rejected(self, migration_ctx, table_name):
+        with pytest.raises(sa.exc.DatabaseError, match="SET NOT NULL"):
+            migration_ctx.alter_column(
+                table_name,
+                "qty",
+                existing_type=sa.Integer(),
+                nullable=False,
+            )
+
+
+class TestYdbTypes(TestBase):
+    def test_ydb_specific_types_survive_a_migration(self, migration_ctx, engine):
+        """The types ``docs/migrations.rst`` recommends for revision bodies."""
+        name = f"types_{unique_suffix()}"
+        try:
+            migration_ctx.create_table(
+                name,
+                sa.Column("id", ydb_types.UInt64, primary_key=True),
+                sa.Column("small", ydb_types.UInt32),
+                sa.Column("amount", ydb_types.Decimal(precision=15, scale=2)),
+                sa.Column("meta", ydb_types.YqlJSON),
+                sa.Column("created", ydb_types.YqlDateTime),
+            )
+
+            with engine.connect() as conn:
+                columns = {c["name"]: c["type"] for c in sa.inspect(conn).get_columns(name)}
+
+            assert isinstance(columns["id"], ydb_types.UInt64)
+            assert isinstance(columns["small"], ydb_types.UInt32)
+            assert isinstance(columns["amount"], sa.DECIMAL)
+            assert (columns["amount"].precision, columns["amount"].scale) == (15, 2)
+            assert isinstance(columns["meta"], sa.JSON)
+            # YqlDateTime is stored with timestamp precision and reflects back
+            # as TIMESTAMP rather than as the type it was declared with.
+            assert isinstance(columns["created"], sa.TIMESTAMP)
+        finally:
+            drop_tables(engine, name)
+
+
+class TestAutogenerate(TestBase):
+    """``--autogenerate`` diffs, exercised through ``compare_metadata``.
+
+    Every comparison is scoped to the table under test, because autogenerate
+    otherwise reports every unrelated table in the database as ``remove_table``.
+    """
+
+    @pytest.fixture
+    def table_name(self, engine):
+        name = f"autogen_{unique_suffix()}"
+        yield name
+        drop_tables(engine, name)
+
+    def _diff(self, engine, metadata, table_name):
+        def include_name(name, type_, parent_names):
+            if type_ == "table":
+                return name == table_name
+            return True
+
+        with engine.connect() as conn:
+            ctx = MigrationContext.configure(
+                conn,
+                opts={"compare_type": True, "include_name": include_name},
+            )
+            return compare_metadata(ctx, metadata)
+
+    def _model(self, table_name, *, extra_column=False, index=False, drop_name=False):
+        metadata = sa.MetaData()
+        columns = [sa.Column("id", sa.Integer, primary_key=True)]
+        if not drop_name:
+            columns.append(sa.Column("name", sa.Unicode))
+        if extra_column:
+            columns.append(sa.Column("qty", sa.Integer))
+        table = sa.Table(table_name, metadata, *columns)
+        if index:
+            sa.Index(f"ix_{table_name}_name", table.c.name)
+        return metadata
+
+    def test_detects_new_table(self, engine, table_name):
+        diff = self._diff(engine, self._model(table_name), table_name)
+
+        assert [op[0] for op in diff] == ["add_table"]
+        assert diff[0][1].name == table_name
+
+    def test_no_diff_when_model_matches_database(self, engine, table_name):
+        metadata = self._model(table_name)
+        with engine.connect() as conn:
+            metadata.create_all(conn)
+            conn.commit()
+
+        assert self._diff(engine, metadata, table_name) == []
+
+    def test_detects_added_column(self, engine, table_name):
+        with engine.connect() as conn:
+            self._model(table_name).create_all(conn)
+            conn.commit()
+
+        diff = self._diff(engine, self._model(table_name, extra_column=True), table_name)
+
+        assert [op[0] for op in diff] == ["add_column"]
+        assert diff[0][3].name == "qty"
+
+    def test_detects_removed_column(self, engine, table_name):
+        with engine.connect() as conn:
+            self._model(table_name).create_all(conn)
+            conn.commit()
+
+        diff = self._diff(engine, self._model(table_name, drop_name=True), table_name)
+
+        assert [op[0] for op in diff] == ["remove_column"]
+        assert diff[0][3].name == "name"
+
+    def test_detects_added_index(self, engine, table_name):
+        with engine.connect() as conn:
+            self._model(table_name).create_all(conn)
+            conn.commit()
+
+        diff = self._diff(engine, self._model(table_name, index=True), table_name)
+
+        assert [op[0] for op in diff] == ["add_index"]
+        assert diff[0][1].name == f"ix_{table_name}_name"
+
+    def test_detects_removed_table(self, engine, table_name):
+        with engine.connect() as conn:
+            self._model(table_name).create_all(conn)
+            conn.commit()
+
+        diff = self._diff(engine, sa.MetaData(), table_name)
+
+        assert [op[0] for op in diff] == ["remove_table"]
+        assert diff[0][1].name == table_name

--- a/test/test_alembic.py
+++ b/test/test_alembic.py
@@ -412,6 +412,46 @@ class TestOperations(TestBase):
         with engine.connect() as conn:
             assert [i["name"] for i in sa.inspect(conn).get_indexes(table_name)] == [index_name]
 
+    def test_alter_column_can_relax_not_null(self, migration_ctx, engine, table_name):
+        """The one ``alter_column`` change YDB accepts, as ``DROP NOT NULL``."""
+        migration_ctx.create_table(
+            table_name,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("label", sa.Unicode(50), nullable=False),
+        )
+        with engine.connect() as conn:
+            before = {c["name"]: c["nullable"] for c in sa.inspect(conn).get_columns(table_name)}
+        assert before["label"] is False
+
+        migration_ctx.alter_column(table_name, "label", existing_type=sa.Unicode(50), nullable=True)
+
+        with engine.connect() as conn:
+            after = {c["name"]: c["nullable"] for c in sa.inspect(conn).get_columns(table_name)}
+        assert after["label"] is True
+
+    def test_execute_can_set_column_options_via_ddl_construct(self, migration_ctx, engine, table_name):
+        """``ALTER COLUMN`` options have no Alembic operation, so raw YQL it is.
+
+        The statement has to be wrapped in ``sa.schema.DDL``. The dialect only
+        routes a statement to the YDB scheme service when SQLAlchemy marks it
+        as DDL, and YDB refuses schema operations inside a transaction, so a
+        plain string reaches the query service instead and is rejected.
+        """
+        self._create(migration_ctx, table_name)
+        statement = f"ALTER TABLE `{table_name}` ALTER COLUMN `name` SET FAMILY default"
+
+        migration_ctx.execute(sa.schema.DDL(statement))
+
+        with pytest.raises(sa.exc.DatabaseError, match="Scheme operations cannot be executed"):
+            migration_ctx.execute(statement)
+
+    def test_add_column_cannot_be_not_null(self, migration_ctx, table_name):
+        """A column added to an existing table is always nullable."""
+        self._create(migration_ctx, table_name)
+
+        with pytest.raises(sa.exc.DatabaseError):
+            migration_ctx.add_column(table_name, sa.Column("required", sa.Unicode(20), nullable=False))
+
     def test_execute_runs_a_data_migration(self, migration_ctx, engine, table_name):
         """The data-migration shape ``docs/migrations.rst`` documents."""
         self._create(migration_ctx, table_name)

--- a/test/test_alembic.py
+++ b/test/test_alembic.py
@@ -403,14 +403,37 @@ class TestOperations(TestBase):
             rows = conn.execute(sa.text(f"SELECT id, name FROM `{table_name}` ORDER BY id")).fetchall()
         assert rows == [(1, "a"), (2, None)]
 
-    def test_create_unique_index_on_non_key_column(self, migration_ctx, engine, table_name):
+    def test_create_index_unique_is_not_enforced(self, migration_ctx, engine, table_name):
+        """``unique=True`` currently yields an index that does not enforce it.
+
+        The dialect compiles the index without ``UNIQUE``, emitting
+        ``ADD INDEX ... GLOBAL SYNC``, and reflection reports ``unique: False``
+        even for an index created as ``GLOBAL UNIQUE SYNC``. YDB itself
+        supports unique indexes and rejects duplicates with ``Conflict with
+        existing key``, so this is a dialect gap, not a YDB limitation.
+
+        The behaviour is pinned here so that fixing the dialect surfaces as a
+        failure and this test, and the support table in the docs, get updated.
+        """
         self._create(migration_ctx, table_name)
         index_name = f"ix_{table_name}_uniq"
 
         migration_ctx.create_index(index_name, table_name, ["name"], unique=True)
 
         with engine.connect() as conn:
-            assert [i["name"] for i in sa.inspect(conn).get_indexes(table_name)] == [index_name]
+            indexes = sa.inspect(conn).get_indexes(table_name)
+        assert [i["name"] for i in indexes] == [index_name]
+        assert indexes[0]["unique"] is False
+
+        with engine.connect() as conn:
+            conn.execute(sa.text(f"UPSERT INTO `{table_name}` (id, name) VALUES (1, 'dup')"))
+            conn.commit()
+        with engine.connect() as conn:
+            conn.execute(sa.text(f"UPSERT INTO `{table_name}` (id, name) VALUES (2, 'dup')"))
+            conn.commit()
+        with engine.connect() as conn:
+            rows = conn.execute(sa.text(f"SELECT name FROM `{table_name}` WHERE name = 'dup'")).fetchall()
+        assert len(rows) == 2, "the duplicate would be rejected if the index were unique"
 
     def test_alter_column_can_relax_not_null(self, migration_ctx, engine, table_name):
         """The one ``alter_column`` change YDB accepts, as ``DROP NOT NULL``."""

--- a/test/test_alembic.py
+++ b/test/test_alembic.py
@@ -403,6 +403,31 @@ class TestOperations(TestBase):
             rows = conn.execute(sa.text(f"SELECT id, name FROM `{table_name}` ORDER BY id")).fetchall()
         assert rows == [(1, "a"), (2, None)]
 
+    def test_create_unique_index_on_non_key_column(self, migration_ctx, engine, table_name):
+        self._create(migration_ctx, table_name)
+        index_name = f"ix_{table_name}_uniq"
+
+        migration_ctx.create_index(index_name, table_name, ["name"], unique=True)
+
+        with engine.connect() as conn:
+            assert [i["name"] for i in sa.inspect(conn).get_indexes(table_name)] == [index_name]
+
+    def test_execute_runs_a_data_migration(self, migration_ctx, engine, table_name):
+        """The data-migration shape ``docs/migrations.rst`` documents."""
+        self._create(migration_ctx, table_name)
+        lightweight = sa.table(
+            table_name,
+            sa.column("id", sa.Integer),
+            sa.column("name", sa.Unicode),
+        )
+        migration_ctx.bulk_insert(lightweight, [{"id": 1, "name": "old"}, {"id": 2, "name": "old"}])
+
+        migration_ctx.execute(lightweight.update().values(name="new"))
+
+        with engine.connect() as conn:
+            rows = conn.execute(sa.text(f"SELECT name FROM `{table_name}`")).fetchall()
+        assert [r[0] for r in rows] == ["new", "new"]
+
 
 class TestUnsupportedOperations(TestBase):
     """YDB limitations that migrations have to be written around.
@@ -450,6 +475,37 @@ class TestUnsupportedOperations(TestBase):
                 existing_type=sa.Integer(),
                 nullable=False,
             )
+
+    def test_foreign_key_is_rejected(self, migration_ctx, engine, table_name):
+        """YDB has no foreign keys, so a referencing table cannot be created."""
+        child = f"{table_name}_child"
+        try:
+            with pytest.raises(sa.exc.DatabaseError):
+                migration_ctx.create_table(
+                    child,
+                    sa.Column("id", sa.Integer, primary_key=True),
+                    sa.Column("parent_id", sa.Integer),
+                    sa.ForeignKeyConstraint(["parent_id"], [f"{table_name}.id"]),
+                )
+        finally:
+            drop_tables(engine, child)
+
+    def test_second_head_is_rejected(self, alembic_env, engine):
+        """Branched history needs a second version row, which cannot exist.
+
+        The version table's primary key is a surrogate column that Alembic
+        never populates, so every row collides on the same ``NULL`` key.
+        """
+        from alembic.runtime.migration import HeadMaintainer
+
+        alembic_env.stamp("head")
+        with engine.connect() as conn:
+            ctx = MigrationContext.configure(conn, opts={"version_table": alembic_env.version_table})
+            heads = HeadMaintainer(ctx, [])
+            heads._insert_version("aaaaaaaaaaaa")
+
+            with pytest.raises(sa.exc.DatabaseError):
+                heads._insert_version("bbbbbbbbbbbb")
 
 
 class TestYdbTypes(TestBase):

--- a/test/test_alembic.py
+++ b/test/test_alembic.py
@@ -9,6 +9,7 @@ Each test works on tables whose names carry a unique suffix, so the suite is
 safe to run against a shared database and does not depend on it being empty.
 """
 
+import io
 import uuid
 
 import pytest
@@ -36,14 +37,26 @@ from ydb_sqlalchemy.alembic import YDBImpl  # noqa: F401
 
 config = context.config
 version_table = config.get_main_option("version_table")
+table_name = config.get_main_option("table_name", None)
+target_metadata = config.attributes.get("target_metadata")
+
+
+def include_name(name, type_, parent_names):
+    # Autogenerate compares against every table in the database; keep it to
+    # the one this test owns so a shared database does not leak in.
+    if type_ == "table" and table_name is not None:
+        return name == table_name
+    return True
+
 
 connectable = sa.create_engine(config.get_main_option("sqlalchemy.url"), poolclass=pool.NullPool)
 try:
     with connectable.connect() as connection:
         context.configure(
             connection=connection,
-            target_metadata=None,
+            target_metadata=target_metadata,
             version_table=version_table,
+            include_name=include_name,
         )
         with context.begin_transaction():
             context.run_migrations()
@@ -136,7 +149,28 @@ class AlembicEnv:
         cfg.set_main_option("script_location", str(self.root / "migrations"))
         cfg.set_main_option("sqlalchemy.url", str(self.url))
         cfg.set_main_option("version_table", self.version_table)
+        cfg.set_main_option("table_name", self.table)
         return cfg
+
+    def config_for(self, metadata) -> Config:
+        """Config whose ``env.py`` will autogenerate against ``metadata``."""
+        cfg = self.config
+        cfg.attributes["target_metadata"] = metadata
+        return cfg
+
+    def config_with_output(self):
+        """Config whose command output is captured.
+
+        ``Config.stdout`` defaults to the ``sys.stdout`` bound at import time,
+        so pytest's capture does not see what the commands print.
+        """
+        buffer = io.StringIO()
+        cfg = self.config
+        cfg.stdout = buffer
+        return cfg, buffer
+
+    def generated_scripts(self):
+        return sorted(self.versions.glob("*.py"))
 
     def add_revision(self, revision: str, upgrade: str, downgrade: str) -> None:
         """Write a revision file chained onto the previously added one."""
@@ -236,6 +270,94 @@ class TestVersionTable(TestBase):
         assert alembic_env.current_heads(engine) == {"0001"}
         with engine.connect() as conn:
             assert not sa.inspect(conn).has_table(alembic_env.table)
+
+
+class TestCommands(TestBase):
+    """The Alembic CLI commands, driven through ``alembic.command``."""
+
+    @pytest.fixture
+    def env(self, alembic_env):
+        alembic_env.add_revision(
+            "0001",
+            "    op.create_table(\n"
+            f"        {alembic_env.table!r},\n"
+            "        sa.Column('id', sa.Integer, primary_key=True),\n"
+            "        sa.Column('name', sa.Unicode),\n"
+            "    )",
+            f"    op.drop_table({alembic_env.table!r})",
+        )
+        return alembic_env
+
+    def test_current_reports_the_applied_revision(self, env):
+        cfg, out = env.config_with_output()
+        command.current(cfg)
+        assert out.getvalue().strip() == ""
+
+        env.upgrade()
+
+        cfg, out = env.config_with_output()
+        command.current(cfg)
+        assert "0001" in out.getvalue()
+
+    def test_history_lists_the_revisions(self, env):
+        env.add_revision(
+            "0002",
+            f"    op.add_column({env.table!r}, sa.Column('qty', sa.Integer))",
+            f"    op.drop_column({env.table!r}, 'qty')",
+        )
+        cfg, out = env.config_with_output()
+
+        command.history(cfg)
+
+        rendered = out.getvalue()
+        assert "0001" in rendered
+        assert "0002" in rendered
+
+    def _model(self, table_name):
+        metadata = sa.MetaData()
+        sa.Table(
+            table_name,
+            metadata,
+            sa.Column("id", sa.Integer, primary_key=True),
+            sa.Column("name", sa.Unicode),
+        )
+        return metadata
+
+    def test_revision_autogenerate_writes_a_create_table(self, alembic_env, engine):
+        """``revision --autogenerate`` against a database without the table.
+
+        Runs on an environment with no revisions yet, since autogenerate
+        refuses to run unless the database is at head.
+        """
+        before = set(alembic_env.generated_scripts())
+
+        command.revision(
+            alembic_env.config_for(self._model(alembic_env.table)),
+            message="create table",
+            autogenerate=True,
+        )
+
+        written = set(alembic_env.generated_scripts()) - before
+        assert len(written) == 1
+        body = written.pop().read_text()
+        assert "op.create_table" in body
+        assert alembic_env.table in body
+        assert "op.drop_table" in body, "the downgrade should be generated too"
+
+    def test_revision_autogenerate_is_empty_when_in_sync(self, env, engine):
+        env.upgrade()
+        before = set(env.generated_scripts())
+
+        command.revision(
+            env.config_for(self._model(env.table)),
+            message="no change",
+            autogenerate=True,
+        )
+
+        written = set(env.generated_scripts()) - before
+        assert len(written) == 1
+        body = written.pop().read_text()
+        assert "op." not in body, f"expected an empty migration, got:\n{body}"
 
 
 class TestUpgradeDowngrade(TestBase):
@@ -705,6 +827,16 @@ class TestAutogenerate(TestBase):
         diff = self._diff(engine, self._model(table_name, index=True), table_name)
 
         assert [op[0] for op in diff] == ["add_index"]
+        assert diff[0][1].name == f"ix_{table_name}_name"
+
+    def test_detects_removed_index(self, engine, table_name):
+        with engine.connect() as conn:
+            self._model(table_name, index=True).create_all(conn)
+            conn.commit()
+
+        diff = self._diff(engine, self._model(table_name), table_name)
+
+        assert [op[0] for op in diff] == ["remove_index"]
         assert diff[0][1].name == f"ix_{table_name}_name"
 
     def test_detects_removed_table(self, engine, table_name):

--- a/test/test_alembic.py
+++ b/test/test_alembic.py
@@ -553,6 +553,31 @@ class TestUnsupportedOperations(TestBase):
         finally:
             drop_tables(engine, child)
 
+    def test_offline_mode_renders_an_unusable_version_insert(self, alembic_env, capsys):
+        """``upgrade --sql`` cannot produce executable YQL for the version table.
+
+        Alembic only supplies ``version_num`` when it inserts a row, so the
+        surrogate primary key column renders as an unfilled bind placeholder.
+        Dropping the surrogate column is not an option either: ``version_num``
+        would become the primary key and the ``UPDATE`` that advances a
+        revision cannot run on YDB.
+
+        Schema statements themselves render fine; it is the version
+        bookkeeping that does not.
+        """
+        alembic_env.add_revision(
+            "0001",
+            "    op.create_table(%r, sa.Column('id', sa.Integer, primary_key=True))" % alembic_env.table,
+            "    op.drop_table(%r)" % alembic_env.table,
+        )
+
+        command.upgrade(alembic_env.config, "head", sql=True)
+
+        rendered = capsys.readouterr().out
+        assert f"CREATE TABLE {alembic_env.table}" in rendered
+        assert f"INSERT INTO {alembic_env.version_table}" in rendered
+        assert "%(id)s" in rendered, "the surrogate key has no value to render"
+
     def test_second_head_is_rejected(self, alembic_env, engine):
         """Branched history needs a second version row, which cannot exist.
 

--- a/test/test_alembic_suite.py
+++ b/test/test_alembic_suite.py
@@ -1,0 +1,29 @@
+"""Alembic's test suite for third-party dialects, run against YDB.
+
+Alembic ships ``alembic.testing.suite`` for dialect authors, the same way
+SQLAlchemy ships its dialect compliance suite. It covers autogenerate
+comparisons and the migration environment, and complements the YDB-specific
+scenarios in ``test_alembic.py``.
+
+Feature flags live in ``test/alembic_requirements.py``; only whole classes and
+individual tests that no flag can express are skipped here.
+"""
+
+import pytest
+
+from ydb_sqlalchemy.alembic import YDBImpl  # noqa: F401  isort:skip
+
+from alembic.testing.suite import *  # noqa: E402,F401,F403
+from alembic.testing.suite import AutogenerateFKOptionsTest as _AutogenerateFKOptionsTest  # noqa: E402
+from alembic.testing.suite import AutoincrementTest as _AutoincrementTest  # noqa: E402
+
+
+@pytest.mark.skip("YDB has no foreign keys")
+class AutogenerateFKOptionsTest(_AutogenerateFKOptionsTest):
+    pass
+
+
+class AutoincrementTest(_AutoincrementTest):
+    @pytest.mark.skip("The fixture table has no primary key, which YDB requires")
+    def test_alter_column_autoincrement_none(self):
+        pass

--- a/ydb_sqlalchemy/alembic.py
+++ b/ydb_sqlalchemy/alembic.py
@@ -1,0 +1,74 @@
+"""Alembic support for the YDB SQLAlchemy dialect.
+
+Alembic dispatches on the SQLAlchemy dialect name and refuses to start when no
+implementation is registered for it, so importing this module is a hard
+requirement for running Alembic against YDB::
+
+    # migrations/env.py
+    from ydb_sqlalchemy.alembic import YDBImpl  # noqa: F401
+
+Importing the module is enough -- Alembic registers :class:`YDBImpl` for the
+``yql`` dialect through the metaclass of its ``DefaultImpl`` base.
+
+This module is optional and is not imported by ``ydb_sqlalchemy`` itself, so
+Alembic stays an optional dependency of the package.
+"""
+
+from typing import Any, Optional
+
+from alembic.ddl.impl import DefaultImpl
+from sqlalchemy import Column, Integer, MetaData, String, Table
+
+__all__ = ["YDBImpl"]
+
+#: Name of the surrogate primary key column added to the Alembic version table.
+VERSION_TABLE_PK_COLUMN = "id"
+
+
+class YDBImpl(DefaultImpl):
+    """Alembic implementation for YDB.
+
+    Registered for the ``yql`` dialect name as a side effect of being defined.
+    """
+
+    __dialect__ = "yql"
+
+    def version_table_impl(
+        self,
+        *,
+        version_table: str,
+        version_table_schema: Optional[str],
+        version_table_pk: bool,
+        **kw: Any,
+    ) -> Table:
+        """Build the ``alembic_version`` table in a form YDB accepts.
+
+        Two YDB constraints rule out Alembic's default version table:
+
+        * Alembic's default table carries a *named* ``PrimaryKeyConstraint``,
+          which SQLAlchemy renders as
+          ``CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num)``. YDB's
+          parser rejects named constraints.
+        * ``version_num`` cannot itself be the primary key, because Alembic
+          advances a revision with
+          ``UPDATE alembic_version SET version_num=<to> WHERE version_num=<from>``
+          and YDB cannot update a primary key column
+          (``Cannot update primary key column: version_num``).
+
+        So the table gets a surrogate primary key column and leaves
+        ``version_num`` writable. YDB requires every table to have a primary
+        key, which is why ``version_table_pk`` is deliberately ignored.
+
+        Alembic only ever supplies ``version_num`` when it inserts a row, so
+        the surrogate column stays ``NULL``. That is what keeps the update
+        atomic, and it is also why branched migrations with more than one head
+        are not supported: a second head would need a second row, and both
+        rows would collide on a ``NULL`` primary key.
+        """
+        return Table(
+            version_table,
+            MetaData(),
+            Column("version_num", String(32), nullable=False),
+            Column(VERSION_TABLE_PK_COLUMN, Integer(), nullable=True, primary_key=True),
+            schema=version_table_schema,
+        )

--- a/ydb_sqlalchemy/sqlalchemy/compiler/base.py
+++ b/ydb_sqlalchemy/sqlalchemy/compiler/base.py
@@ -363,7 +363,13 @@ class BaseYqlCompiler(StrSQLCompiler):
         if bind_name in self.column_keys and hasattr(self.compile_state, "dml_table"):
             if bind_name in self.compile_state.dml_table.c:
                 column = self.compile_state.dml_table.c[bind_name]
-                return column.nullable and not column.primary_key
+                # Lightweight constructs built with sa.table()/sa.column() -- the form
+                # alembic documents for op.bulk_insert() -- yield ColumnClause objects,
+                # which carry neither nullable nor primary_key. Fall back to the same
+                # answer as for a column that is not part of the statement at all.
+                nullable = getattr(column, "nullable", False)
+                primary_key = getattr(column, "primary_key", False)
+                return nullable and not primary_key
         return False
 
     def _guess_bound_variable_type_by_parameters(


### PR DESCRIPTION
Closes #117.

Alembic support was documented and exercised only by `examples/alembic`, with nothing verifying it. Writing the tests surfaced that the integration code was never shipped: every `env.py` had to define its own `DefaultImpl` subclass and overwrite the private `MigrationContext._version`. That now lives in `ydb_sqlalchemy.alembic`, built on Alembic's public `version_table_impl` hook, so `env.py` just imports it.

`docs/migrations.rst` now opens with a **Support Status** section stating per command and per operation what works and what does not. Every row in it is backed by a test, in both directions — the unsupported ones are asserted too, so a future YDB release lifting a restriction shows up as a failing test rather than as stale prose.

**Tests.** `test/test_alembic.py` (31 cases, ~30s): version table shape and head tracking; `upgrade`/`downgrade` over a three-revision chain, stepwise and to base; `stamp`; the operations usable in a revision body; autogenerate diffs including the empty diff when the model is in sync; YDB types; and the operations YDB rejects. Table names carry a unique suffix, so the suite is safe against a shared database.

**Bugs found:**

- `op.bulk_insert()` with `sa.table()`/`sa.column()` — the form Alembic documents — raised `AttributeError` because `_is_bound_to_nullable_column` assumed `.nullable`/`.primary_key`, which `ColumnClause` does not have. Fixed in the compiler.
- The docs presented `alter_column` widening a string as supported, and used `alter_column(..., nullable=False)` in two examples. YDB accepts neither. Replaced with add-copy-drop.
- The `create_table` example declared a `ForeignKeyConstraint`. YDB has no foreign keys, so that example could never have run.

**Where `alter_column` actually stands**, since it is the fiddly part: YDB's `ALTER COLUMN` changes column *options* and can `DROP NOT NULL`, but cannot change a type. So `alter_column(nullable=True)` works, while `nullable=False` and `type_=` do not. The remaining options have no Alembic operation and need `op.execute(sa.schema.DDL(...))` — a plain string is not marked as DDL by SQLAlchemy, so the dialect sends it to the query service and YDB rejects it.

**Worth a look in review:** `version_table_impl` keeps the documented layout — a surrogate always-`NULL` `id` as primary key — rather than the more obvious `version_num` primary key. `version_num` cannot be the key because Alembic advances a revision with `UPDATE ... SET version_num`, and YDB cannot update a key column. The consequence, now tested and documented, is that branched history is unsupported.

Alembic also ships `alembic.testing.suite` for third-party dialects, which nothing was running here. It now runs from `test/test_alembic_suite.py` with the YDB feature flags in `test/alembic_requirements.py`: 22 passed, 84 skipped, none failing. Wiring it needs one requirements class serving both suites, since Alembic reads its flags off the same object as SQLAlchemy.

**A third bug, found while comparing against the Liquibase dialect:** `create_index(unique=True)` compiles to `ADD INDEX ... GLOBAL SYNC` without `UNIQUE`, so the index does not enforce uniqueness, and reflection reports `unique: False` even for one that does. YDB supports unique indexes and rejects duplicates on them. Not fixed here — it is a dialect concern, not an Alembic one — but the test now inserts a duplicate and asserts it is accepted, so fixing it will fail the test and force the docs to follow. Liquibase rejects `unique` indexes outright rather than downgrading them silently.

Offline mode (`upgrade --sql`) is untested and the table says so rather than guessing.

On a clean database the main suite has one pre-existing failure (`test_ydb_credentials_good`, an `Unauthorized` from the environment), identical before and after, including after the `requirement_cls` change.

Also drops the `## Unreleased ##` heading this branch had added to `CHANGELOG.md`: `python-publish.yml` reads the release notes as everything above the first `## ` line, so it would have made them empty and failed the publish job with `CHANGELOG empty`, and `increment_version.py` would have skipped inserting the real version header. Pending entries are bare bullets now, and the rule is written down in a new `AGENTS.md` — same reasoning as ydb-platform/ydb-python-sdk#892, which this repository had no equivalent of.
